### PR TITLE
Travis: Don't capture test output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 script:
   - cargo build --verbose
-  - cargo test -- -nocapture
+  - cargo test -- --nocapture
 rust:
   - nightly
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: rust
+script:
+  - cargo build --verbose
+  - cargo test -- -nocapture
 rust:
   - nightly
 node_js:
   - "8"
 before_install:
-  - "npm install shift-codegen"
-  - "npm install shift-scope"
-  - "npm install shift-parser"
+  - "npm install"


### PR DESCRIPTION
This should help with https://github.com/binast/binjs-ref/pull/76 by making sure that Travis sees progress even with long-running test_roundtrip.