### PR TITLE
Add missing node name into multipart grammar document

### DIFF
--- a/crates/binjs_io/src/multipart/mod.rs
+++ b/crates/binjs_io/src/multipart/mod.rs
@@ -57,6 +57,7 @@
 //!      - byte length of entry (`varnum`);
 //!    - for each entry,
 //!      - byte length of node name (`varnum`);
+//!      - node name (utf-8 encoded string);
 //!      - number of fields (`varnum`);
 //!      - for each field
 //!        - byte length of field name (`varnum`);


### PR DESCRIPTION
In multipart document, "node name" seems to be missing in the grammar table, compared to the implementation,
so added it to the document.

also, I cannot find the implementation for reading fields.
I haven't touched that document tho.
