### PR TITLE
Scope cleanups and function name order

### DIFF
--- a/crates/binjs_es6/src/scopes.rs
+++ b/crates/binjs_es6/src/scopes.rs
@@ -199,6 +199,12 @@ impl Visitor<()> for AnnotationVisitor {
         Ok(None)
     }
 
+    fn exit_assignment_target_identifier(&mut self, _path: &Path, node: &mut AssignmentTargetIdentifier) -> Result<Option<AssignmentTargetIdentifier>, ()> {
+        self.free_names_in_function_stack.last_mut()
+            .unwrap()
+            .insert(node.name.clone());
+        Ok(None)
+    }
 
     fn exit_binding_identifier(&mut self, path: &Path, node: &mut BindingIdentifier) -> Result<Option<BindingIdentifier>, ()> {
         match path.get(0) {

--- a/crates/binjs_es6/src/scopes.rs
+++ b/crates/binjs_es6/src/scopes.rs
@@ -426,15 +426,16 @@ impl Visitor<()> for AnnotationVisitor {
         // 3. Otherwise, the name is declared as a `let`.
         let name = name.to_string();
         debug!(target: "annotating", "exit_function_declaration sees {} at {:?}", node.name.name, path.get(0));
-        match path.get(0) {
-            None => {
+        match path.get(0).expect("Impossible AST walk") {
+            &PathItem { field: ASTField::Statements, interface: ASTNode::Script } |
+            &PathItem { field: ASTField::Statements, interface: ASTNode::Module } => {
                 // Case 1.
                 debug!(target: "annotating", "exit_function_declaration says it's a var (case 1)");
                 self.var_names_stack.last_mut()
                     .unwrap()
                     .insert(name);
             }
-            Some(&PathItem { field: ASTField::Statements, interface: ASTNode::FunctionBody }) =>
+            &PathItem { field: ASTField::Statements, interface: ASTNode::FunctionBody } =>
             {
                 // Case 2.
                 debug!(target: "annotating", "exit_function_declaration says it's a var (case 2)");
@@ -442,7 +443,7 @@ impl Visitor<()> for AnnotationVisitor {
                     .unwrap()
                     .insert(name);
             }
-            Some(_) => {
+            _ => {
                 // Case 3.
                 debug!(target: "annotating", "exit_function_declaration says it's a lex (case 3)");
                 self.lex_names_stack.last_mut()

--- a/spec/es6.webidl
+++ b/spec/es6.webidl
@@ -428,9 +428,9 @@ interface EagerMethod : Node {
   attribute boolean isAsync;
   // True for `GeneratorMethod`, false otherwise.
   attribute boolean isGenerator;
+  attribute PropertyName name;
   attribute AssertedParameterScope? parameterScope;
   attribute AssertedVarScope? bodyScope;
-  attribute PropertyName name;
   // The `UniqueFormalParameters`.
   attribute FormalParameters params;
   attribute FunctionBody body;
@@ -442,8 +442,8 @@ interface EagerMethod : Node {
 
 // `get PropertyName ( ) { FunctionBody }`
 interface EagerGetter : Node {
-  attribute AssertedVarScope? bodyScope;
   attribute PropertyName name;
+  attribute AssertedVarScope? bodyScope;
   attribute FunctionBody body;
 };
 
@@ -453,9 +453,9 @@ interface EagerGetter : Node {
 
 // `set PropertyName ( PropertySetParameterList ) { FunctionBody }`
 interface EagerSetter : Node {
+  attribute PropertyName name;
   attribute AssertedParameterScope? parameterScope;
   attribute AssertedVarScope? bodyScope;
-  attribute PropertyName name;
   // The `PropertySetParameterList`.
   attribute Parameter param;
   attribute FunctionBody body;
@@ -605,9 +605,9 @@ interface ConditionalExpression : Node {
 interface EagerFunctionExpression : Node {
   attribute boolean isAsync;
   attribute boolean isGenerator;
+  attribute BindingIdentifier? name;
   attribute AssertedParameterScope? parameterScope;
   attribute AssertedVarScope? bodyScope;
-  attribute BindingIdentifier? name;
   attribute FormalParameters params;
   attribute FunctionBody body;
 };
@@ -857,9 +857,9 @@ interface FunctionBody : Node {
 interface EagerFunctionDeclaration : Node {
   attribute boolean isAsync;
   attribute boolean isGenerator;
+  attribute BindingIdentifier name;
   attribute AssertedParameterScope? parameterScope;
   attribute AssertedVarScope? bodyScope;
-  attribute BindingIdentifier name;
   attribute FormalParameters params;
   attribute FunctionBody body;
 };


### PR DESCRIPTION
Fix a few bugs in scopes.rs discovered while trying to run encoded programs.

Change the order in which functions have their names serialized.