### PR TITLE
Don't launder away is_skippable when deanonymizing types

### DIFF
--- a/crates/binjs_meta/src/export.rs
+++ b/crates/binjs_meta/src/export.rs
@@ -115,6 +115,7 @@ impl TypeDeanonymizer {
             for field in fields.drain(..) {
                 declaration.with_field(field.name(), field.type_().clone());
             }
+            declaration.with_skippable(interface.is_skippable());
         }
         // Copy and deanonymize typedefs
         for (name, definition) in spec.typedefs_by_name() {


### PR DESCRIPTION
Looks like we just forgot to forward this information when doing type deanonymization.

Is this supposed to bump some micro-version?