### PR TITLE
Normalize binjs_io::multipart::write import section for readability.

### DIFF
--- a/crates/binjs_io/src/multipart/write.rs
+++ b/crates/binjs_io/src/multipart/write.rs
@@ -1,23 +1,35 @@
+use TokenWriterError;
+
 use bytes;
-use bytes::compress::*;
-use bytes::varnum::*;
-use io::*;
-use ::TokenWriterError;
-use multipart::*;
+use bytes::compress::Compression;
+use bytes::compress::CompressionResult;
+use bytes::varnum::WriteVarNum;
+use io::TokenWriter;
+
+use multipart::FormatInTable;
+use multipart::HEADER_GRAMMAR_TABLE;
+use multipart::HEADER_STRINGS_TABLE;
+use multipart::HEADER_TREE;
 
 use std;
-use std::collections::{ HashMap, HashSet };
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::cell::RefCell;
-use std::fmt::{ Debug, Display, Formatter };
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::hash::Hash;
 use std::io::Write;
-use std::ops::{ Add, AddAssign };
+use std::ops::Add;
+use std::ops::AddAssign;
 use std::rc::Rc;
 
-use rand::{ Rand, Rng };
+use rand::Rand;
+use rand::Rng;
 
 use vec_map;
-use vec_map::*;
+use vec_map::VecMap;
+
 
 /// Instructions for a single section (grammar, strings, tree, ...)
 #[derive(Clone, Debug)]


### PR DESCRIPTION
I'm starting to read through this code and get an understanding of it.  I found that the import usage in most of the files made it very hard to track down where definitions were coming from.  I'm going to try to make every import name explicit, and avoid '*' imports.

I plan on cleaning this up a bit at a time as I run across it.  This is the first one.