### PR TITLE
Update idl to match ecmascript-binary-ast f2bbb2a69fa0d37a36efa70716cf7d6e5fe10851

### DIFF
--- a/crates/binjs_es6/src/lazy.rs
+++ b/crates/binjs_es6/src/lazy.rs
@@ -84,32 +84,40 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         self.cut_at_threshold()
     }
 
-    /// Convert eager getter/setter/method to skippable.
+    /// Convert eager getter/setter/method to lazy.
     ///
     /// Only called if we haven't skipped the subtree.
     fn exit_method_definition(&mut self, _path: &Path, node: &mut ViewMutMethodDefinition) -> Result<Option<MethodDefinition>, ()> {
         match *node {
             ViewMutMethodDefinition::EagerGetter(ref mut steal) => {
                 Self::steal(*steal, |stolen| {
-                    SkippableGetter {
-                        skip: Offset::default(),
-                        skipped: stolen,
+                    LazyGetter {
+                        name: stolen.name,
+                        directives: stolen.directives,
+                        contents_skip: Offset::default(),
+                        contents: stolen.contents
                     }.into()
                 })
             }
             ViewMutMethodDefinition::EagerSetter(ref mut steal) => {
                 Self::steal(*steal, |stolen| {
-                    SkippableSetter {
-                        skip: Offset::default(),
-                        skipped: stolen,
+                    LazySetter {
+                        name: stolen.name,
+                        directives: stolen.directives,
+                        contents_skip: Offset::default(),
+                        contents: stolen.contents
                     }.into()
                 })
             }
             ViewMutMethodDefinition::EagerMethod(ref mut steal) => {
                 Self::steal(*steal, |stolen| {
-                    SkippableMethod {
-                        skip: Offset::default(),
-                        skipped: stolen,
+                    LazyMethod {
+                        is_async: stolen.is_async,
+                        is_generator: stolen.is_generator,
+                        name: stolen.name,
+                        directives: stolen.directives,
+                        contents_skip: Offset::default(),
+                        contents: stolen.contents
                     }.into()
                 })
             }
@@ -122,16 +130,20 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         self.cut_at_threshold()
     }
 
-    /// Convert eager function declarations to skippable.
+    /// Convert eager function declarations to lazy.
     ///
     /// Only called if we haven't skipped the subtree.
     fn exit_function_declaration(&mut self, _path: &Path, node: &mut ViewMutFunctionDeclaration) -> Result<Option<FunctionDeclaration>, ()> {
         match *node {
             ViewMutFunctionDeclaration::EagerFunctionDeclaration(ref mut steal) => {
                 Self::steal(*steal, |stolen| {
-                    SkippableFunctionDeclaration {
-                        skip: Offset::default(),
-                        skipped: stolen,
+                    LazyFunctionDeclaration {
+                        is_async: stolen.is_async,
+                        is_generator: stolen.is_generator,
+                        name: stolen.name,
+                        directives: stolen.directives,
+                        contents_skip: Offset::default(),
+                        contents: stolen.contents
                     }.into()
                 })
             }
@@ -144,7 +156,7 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         self.cut_at_threshold()
     }
 
-    /// Convert eager function expressions to skippable, unless they're called immediately.
+    /// Convert eager function expressions to lazy, unless they're called immediately.
     ///
     /// Only called if we haven't skipped the subtree.
     fn exit_function_expression(&mut self, path: &Path, node: &mut ViewMutFunctionExpression) -> Result<Option<FunctionExpression>, ()> {
@@ -155,9 +167,13 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         match *node {
             ViewMutFunctionExpression::EagerFunctionExpression(ref mut steal) => {
                 Self::steal(*steal, |stolen| {
-                    SkippableFunctionExpression {
-                        skip: Offset::default(),
-                        skipped: stolen,
+                    LazyFunctionExpression {
+                        is_async: stolen.is_async,
+                        is_generator: stolen.is_generator,
+                        name: stolen.name,
+                        directives: stolen.directives,
+                        contents_skip: Offset::default(),
+                        contents: stolen.contents
                     }.into()
                 })
             }

--- a/crates/binjs_es6/src/lib.rs
+++ b/crates/binjs_es6/src/lib.rs
@@ -25,4 +25,4 @@ pub mod io;
 pub mod scopes;
 
 /// Introducing laziness in an AST.
-pub mod skip;
+pub mod lazy;

--- a/crates/binjs_io/src/multipart/read.rs
+++ b/crates/binjs_io/src/multipart/read.rs
@@ -233,7 +233,7 @@ impl TreeTokenReader {
     pub fn new<R: Read + Seek>(mut reader: R) -> Result<Self, TokenReaderError> {
         // Check magic headers.
         const MAGIC_HEADER: &'static [u8; 5] = b"BINJS";
-        const FORMAT_VERSION: u32 = 0;
+        const FORMAT_VERSION: u32 = 1;
 
         reader.read_const(MAGIC_HEADER)
             .map_err(TokenReaderError::ReadError)?;

--- a/crates/binjs_meta/src/export.rs
+++ b/crates/binjs_meta/src/export.rs
@@ -77,13 +77,21 @@ impl TypeDeanonymizer {
             builder: SpecBuilder::new(),
             supersums_of: HashMap::new(),
         };
+        let mut skip_name_map: HashMap<&FieldName, FieldName> = HashMap::new();
+
         // Copy field names
         for (_, name) in spec.field_names() {
             result.builder.import_field_name(name)
         }
 
-        // We may need to introduce name `_skip`, we'll see.
-        let mut field_skip = None;
+        for (_, interface) in spec.interfaces_by_name() {
+            for field in interface.contents().fields() {
+                if field.is_lazy() {
+                    let skip_name = result.builder.field_name(format!("{}_skip", field.name().to_str()).to_str());
+                    skip_name_map.insert(field.name(), skip_name);
+                }
+            }
+        }
 
         // Copy and deanonymize interfaces.
         for (name, interface) in spec.interfaces_by_name() {
@@ -92,16 +100,6 @@ impl TypeDeanonymizer {
             // and walk through their fields to deanonymize types.
 
             let mut fields = vec![];
-            // If the interface is skippable, introduce a first invisible field `_skip`.
-            if interface.is_skippable() {
-                let name = field_skip.get_or_insert_with(||
-                    result.builder.field_name("_skip")
-                );
-                fields.push(Field::new(
-                    name.clone(),
-                    Type::offset().required()
-                ))
-            }
 
             // Copy other fields.
             for field in interface.contents().fields() {
@@ -113,9 +111,16 @@ impl TypeDeanonymizer {
             let mut declaration = result.builder.add_interface(name)
                 .unwrap();
             for field in fields.drain(..) {
-                declaration.with_field(field.name(), field.type_().clone());
+                // Create *_skip field just before the lazy field.
+                // See also tagged_tuple in write.rs.
+                if field.is_lazy() {
+                    declaration.with_field(skip_name_map.get(field.name()).unwrap(),
+                                           Type::offset().required(),
+                                           Laziness::Eager);
+                }
+                declaration.with_field(field.name(), field.type_().clone(),
+                                       field.laziness());
             }
-            declaration.with_skippable(interface.is_skippable());
         }
         // Copy and deanonymize typedefs
         for (name, definition) in spec.typedefs_by_name() {

--- a/crates/binjs_meta/src/import.rs
+++ b/crates/binjs_meta/src/import.rs
@@ -1,4 +1,4 @@
-use spec::{ self, SpecBuilder, TypeSum };
+use spec::{ self, SpecBuilder, TypeSum, Laziness };
 
 use webidl::ast::*;
 
@@ -12,33 +12,52 @@ impl Importer {
     /// extern crate binjs_meta;
     /// extern crate webidl;
     /// use webidl;
+    /// use binjs_meta::spec::SpecOptions;
     ///
     /// let ast = webidl::parse_string("
-    ///    [Skippable] interface SkippableFoo {
-    ///       attribute EagerFoo eager;
+    ///    interface FooContents {
+    ///      attribute boolean value;
+    ///    };
+    ///    interface LazyFoo {
+    ///       [Lazy] attribute FooContents contents;
     ///    };
     ///    interface EagerFoo {
-    ///       attribute bool value;
+    ///       attribute FooContents contents;
     ///    };
     /// ").expect("Could not parse");
     ///
     /// let mut builder = binjs_meta::import::Importer::import(&ast);
     ///
-    /// let name_eager = builder.get_node_name("EagerFoo")
+    /// let fake_root = builder.node_name("@@ROOT@@"); // Unused
+    /// let null = builder.node_name(""); // Used
+    /// let spec = builder.into_spec(SpecOptions {
+    ///     root: &fake_root,
+    ///     null: &null,
+    /// });
+    ///
+    /// let name_eager = spec.get_node_name("EagerFoo")
     ///     .expect("Missing name EagerFoo");
-    /// let name_skippable = builder.get_node_name("SkippableFoo")
-    ///     .expect("Missing name SkippableFoo");
+    /// let name_lazy = spec.get_node_name("LazyFoo")
+    ///     .expect("Missing name LazyFoo");
+    /// let name_contents = spec.get_field_name("contents")
+    ///     .expect("Missing name contents");
     ///
     /// {
-    ///     let interface_eager = builder.get_interface(&name_eager)
+    ///     let interface_eager = spec.get_interface_by_name(&name_eager)
     ///         .expect("Missing interface EagerFoo");
-    ///     assert_eq!(interface_eager.is_skippable(), false);
+    ///     let contents_field =
+    ///         interface_eager.get_field_by_name(&name_contents)
+    ///         .expect("Missing field contents");
+    ///     assert_eq!(contents_field.is_lazy(), false);
     /// }
     ///
     /// {
-    ///     let interface_skippable = builder.get_interface(&name_skippable)
-    ///         .expect("Missing interface SkippableFoo");
-    ///     assert_eq!(interface_skippable.is_skippable(), true);
+    ///     let interface_lazy = spec.get_interface_by_name(&name_lazy)
+    ///         .expect("Missing interface LazyFoo");
+    ///     let contents_field =
+    ///         interface_lazy.get_field_by_name(&name_contents)
+    ///         .expect("Missing field contents");
+    ///     assert_eq!(contents_field.is_lazy(), true);
     /// }
     /// ```
     pub fn import(ast: &AST) -> SpecBuilder {
@@ -95,7 +114,19 @@ impl Importer {
             if let InterfaceMember::Attribute(Attribute::Regular(ref attribute)) = *member {
                 let name = self.builder.field_name(&attribute.name);
                 let type_ = self.convert_type(&*attribute.type_);
-                fields.push((name, type_));
+                let mut laziness = Laziness::Eager;
+
+                for extended_attribute in &attribute.extended_attributes {
+                    use webidl::ast::ExtendedAttribute::NoArguments;
+                    use webidl::ast::Other::Identifier;
+                    if let &NoArguments(Identifier(ref id)) = extended_attribute.as_ref() {
+                        if &*id == "Lazy" {
+                            laziness = Laziness::Lazy;
+                        }
+                    }
+                }
+
+                fields.push((name, type_, laziness));
             } else {
                 panic!("Expected an attribute, got {:?}", member);
             }
@@ -103,18 +134,8 @@ impl Importer {
         let name = self.builder.node_name(&interface.name);
         let mut node = self.builder.add_interface(&name)
             .expect("Name already present");
-        for (field_name, field_type) in fields.drain(..) {
-            node.with_field(&field_name, field_type);
-        }
-
-        for extended_attribute in &interface.extended_attributes {
-            use webidl::ast::ExtendedAttribute::NoArguments;
-            use webidl::ast::Other::Identifier;
-            if let &NoArguments(Identifier(ref id)) = extended_attribute.as_ref() {
-                if &*id == "Skippable" {
-                    node.with_skippable(true);
-                }
-            }
+        for (field_name, field_type, field_laziness) in fields.drain(..) {
+            node.with_field(&field_name, field_type, field_laziness);
         }
     }
     fn convert_type(&mut self, t: &Type) -> spec::Type {

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -144,7 +144,7 @@ fn handle_path<'a>(options: &Options<'a>,
     if options.lazification > 0 {
         println!("Introducing laziness.");
         let mut path = binjs::specialized::es6::ast::Path::new();
-        let mut visitor = binjs::specialized::es6::skip::LazifierVisitor::new(options.lazification);
+        let mut visitor = binjs::specialized::es6::lazy::LazifierVisitor::new(options.lazification);
         ast.walk(&mut path, &mut visitor)
             .expect("Could not introduce laziness");
     }

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -183,6 +183,18 @@ impl SourceParser for Shift {
     }
 }
 
+#[derive(PartialEq)]
+enum FunctionKind {
+    FunctionDeclaration,
+    Method,
+    FunctionExpression,
+    ArrowExpression,
+    ArrowExpressionWithFunctionBody,
+    ArrowExpressionWithExpression,
+    Getter,
+    Setter,
+}
+
 /// A data structure designed to convert from Shift AST to BinJS AST.
 struct FromShift;
 impl FromShift {
@@ -209,11 +221,127 @@ impl FromShift {
         object.insert("type", json::from(kind));
     }
 
+    fn dummy_declared_scope(&self, name: &str) -> json::JsonValue {
+        let mut scope = Object::new();
+        scope["type"] = json::from(name);
+        scope["declaredNames"] = array![];
+        scope["hasDirectEval"] = JSON::Boolean(false);
+        JSON::Object(scope)
+    }
+
+    fn dummy_parameter_scope<'a, I>(&self, params: I) -> json::JsonValue
+    where I: IntoIterator<Item=&'a json::JsonValue> {
+        let mut scope = Object::new();
+        scope["type"] = json::from("AssertedParameterScope");
+        scope["boundNames"] = array![];
+        scope["hasDirectEval"] = JSON::Boolean(false);
+
+        let mut is_simple_parameter_list = true;
+        for item in params {
+            match item["type"].as_str() {
+                Some("BindingIdentifier") => {
+                }
+                _ => {
+                    is_simple_parameter_list = false;
+                    break;
+                }
+            }
+        }
+
+        scope["isSimpleParameterList"] = JSON::Boolean(is_simple_parameter_list);
+        JSON::Object(scope)
+    }
+
+    fn dummy_bound_names_scope(&self) -> json::JsonValue {
+        let mut scope = Object::new();
+        scope["type"] = json::from("AssertedBoundNamesScope");
+        scope["boundNames"] = array![];
+        scope["hasDirectEval"] = JSON::Boolean(true);
+        JSON::Object(scope)
+    }
+
+    fn create_function_contents(&self, object: &mut json::object::Object, kind: FunctionKind) {
+        assert!(kind != FunctionKind::ArrowExpressionWithFunctionBody);
+        assert!(kind != FunctionKind::ArrowExpressionWithExpression);
+        if kind != FunctionKind::Getter && kind != FunctionKind::Setter {
+            // `isAsync` is not supported by the parser yet.
+            if let None = object.get("isAsync") {
+                object["isAsync"] = JSON::Boolean(false)
+            }
+        }
+
+        let directives = if object["body"].has_key("directives") {
+            object["body"].remove("directives")
+        } else {
+            json::JsonValue::new_array()
+        };
+
+        let is_expression_body;
+        let mut body = object.remove("body").unwrap();
+        match body["type"].as_str() {
+            Some("FunctionBody") => {
+                body = body.remove("statements");
+                is_expression_body = false;
+            }
+            _ => {
+                is_expression_body = true;
+            }
+        }
+
+        let mut contents = Object::new();
+        match kind {
+            FunctionKind::FunctionDeclaration | FunctionKind::Method => {
+                contents["type"] = json::from("FunctionOrMethodContents");
+                contents["isThisCaptured"] = JSON::Boolean(false);
+            }
+            FunctionKind::FunctionExpression => {
+                contents["type"] = json::from("FunctionExpressionContents");
+                contents["isFunctionNameCaptured"] = JSON::Boolean(false);
+                contents["isThisCaptured"] = JSON::Boolean(false);
+            }
+            FunctionKind::ArrowExpression => {
+                if is_expression_body {
+                    object["type"] = json::from("ArrowExpressionWithExpression");
+                    contents["type"] = json::from("ArrowExpressionContentsWithExpression");
+                } else {
+                    object["type"] = json::from("ArrowExpressionWithFunctionBody");
+                    contents["type"] = json::from("ArrowExpressionContentsWithFunctionBody");
+                }
+            }
+            FunctionKind::Getter => {
+                contents["type"] = json::from("GetterContents");
+                contents["isThisCaptured"] = JSON::Boolean(false);
+            }
+            FunctionKind::Setter => {
+                contents["type"] = json::from("SetterContents");
+                contents["isThisCaptured"] = JSON::Boolean(false);
+            }
+            _ => {
+                panic!("unexpected FunctionKind");
+            }
+        }
+        if kind != FunctionKind::Getter {
+            if kind == FunctionKind::Setter {
+                contents["param"] = object.remove("param").unwrap();
+                contents["parameterScope"] = self.dummy_parameter_scope(vec![&contents["param"]]);
+            } else {
+                contents["params"] = object.remove("params").unwrap();
+                assert!(contents["params"]["items"].is_array());
+                contents["parameterScope"] = self.dummy_parameter_scope(contents["params"]["items"].members());
+            }
+        }
+        contents["bodyScope"] = self.dummy_declared_scope("AssertedVarScope");
+        contents["body"] = body;
+        object.insert("contents", JSON::Object(contents));
+        object.insert("directives", directives);
+        self.make_eager(object);
+    }
+
     fn convert_object(&self, object: &mut json::object::Object) {
         // By alphabetical order
         match object["type"].as_str() {
             Some("Block") => {
-                object.insert("scope", JSON::Null);
+                object.insert("scope", self.dummy_declared_scope("AssertedBlockScope"));
             }
             Some("BlockStatement") => {
                 // Rewrite
@@ -248,16 +376,23 @@ impl FromShift {
                     object["left"].remove("declarators");
                 }
             }
-            Some("Function") | Some("FunctionDeclaration") | Some("FunctionExpression") | Some("Method")  | Some("ArrowExpression") => {
-                // `isAsync` is not supported by the parser yet.
-                if let None = object.get("isAsync") {
-                    object["isAsync"] = JSON::Boolean(false)
-                }
-                object.insert("scope", JSON::Null);
-                self.make_eager(object);
+            Some("FunctionDeclaration") => {
+                self.create_function_contents(object, FunctionKind::FunctionDeclaration);
             }
-            Some("Getter") | Some("Setter") => {
-                self.make_eager(object);
+            Some("Method") => {
+                self.create_function_contents(object, FunctionKind::Method);
+            }
+            Some("FunctionExpression") => {
+                self.create_function_contents(object, FunctionKind::FunctionExpression);
+            }
+            Some("ArrowExpression") => {
+                self.create_function_contents(object, FunctionKind::ArrowExpression);
+            }
+            Some("Getter") => {
+                self.create_function_contents(object, FunctionKind::Getter);
+            }
+            Some("Setter") => {
+                self.create_function_contents(object, FunctionKind::Setter);
             }
             Some("LabeledStatement") => {
                 // Rewrite type
@@ -281,6 +416,12 @@ impl FromShift {
                     flags.push('u');
                 }
                 object.insert("flags", json::from(flags));
+            }
+            Some("Script") => {
+                object.insert("scope", self.dummy_declared_scope("AssertedScriptGlobalScope"));
+            }
+            Some("CatchClause") => {
+                object.insert("bindingScope", self.dummy_bound_names_scope());
             }
             Some("StaticPropertyName") => {
                 // Change type.
@@ -318,17 +459,51 @@ impl FromShift {
 
 struct ToShift;
 impl ToShift {
-    fn remove_eager_or_skippable(&self, obj: &mut json::object::Object) {
+    fn remove_eager_or_lazy(&self, obj: &mut json::object::Object) {
         let kind = { obj["type"].as_str().unwrap().to_string()  };
         const EAGER : &'static str = "Eager";
-        const SKIPPABLE : &'static str = "Skippable";
+        const LAZY : &'static str = "Lazy";
 
         if kind.starts_with(EAGER) {
             obj["type"] = json::from(&kind[EAGER.len()..])
-        } else if kind.starts_with(SKIPPABLE) {
-            obj["type"] = json::from(&kind[SKIPPABLE.len()..])
+        } else if kind.starts_with(LAZY) {
+            obj["type"] = json::from(&kind[LAZY.len()..])
         } else {
             panic!()
+        }
+    }
+    fn remove_with_suffix(&self, obj: &mut json::object::Object) {
+        let kind = { obj["type"].as_str().unwrap().to_string()  };
+        const WITHFUNCTIONBODY : &'static str = "WithFunctionBody";
+        const WITHEXPRESSION : &'static str = "WithExpression";
+
+        if kind.ends_with(WITHFUNCTIONBODY) {
+            obj["type"] = json::from(&kind[..(kind.len() - WITHFUNCTIONBODY.len())])
+        } else if kind.ends_with(WITHEXPRESSION) {
+            obj["type"] = json::from(&kind[..(kind.len() - WITHEXPRESSION.len())])
+        }
+    }
+    fn remove_function_contents(&self, obj: &mut json::object::Object, kind: FunctionKind) {
+        self.remove_eager_or_lazy(obj);
+        self.remove_with_suffix(obj);
+
+        // Remove unused fields.
+        obj.remove("isAsync");
+        obj.remove("scope");
+        obj.remove("contents_skip");
+
+        // Move some fields back from *Contents.
+        let mut contents = obj.remove("contents").unwrap();
+        obj["params"] = contents.remove("params");
+
+        if kind == FunctionKind::ArrowExpressionWithExpression {
+            obj["body"] = contents.remove("body");
+        } else {
+            let mut body = Object::new();
+            body["type"] = json::from("FunctionBody");
+            body["directives"] = obj.remove("directives").unwrap();
+            body["statements"] = contents.remove("body");
+            obj["body"] = JSON::Object(body);
         }
     }
 }
@@ -381,6 +556,14 @@ impl MutASTVisitor for ToShift {
                 // - `object` is `VariableDeclarationStatement`.
                 // - `insert` is `VariableDeclaration`.
                 object["declaration"] = JSON::Object(insert);
+            }
+            (_, "Script", &mut JSON::Object(ref mut object)) => {
+                // Remove unused field.
+                object.remove("scope");
+            }
+            (_, "CatchClause", &mut JSON::Object(ref mut object)) => {
+                // Remove unused field.
+                object.remove("bindingScope");
             }
             (_, "LabelledStatement", &mut JSON::Object(ref mut object)) => {
                 // Change type.
@@ -444,19 +627,32 @@ impl MutASTVisitor for ToShift {
                 ];
             }
             (_, "EagerFunctionExpression", &mut JSON::Object(ref mut object))
-            | (_, "SkippableFunctionExpression", &mut JSON::Object(ref mut object))
-            | (_, "EagerFunctionDeclaration", &mut JSON::Object(ref mut object))
-            | (_, "SkippableFunctionDeclaration", &mut JSON::Object(ref mut object))
-            | (_, "EagerMethod", &mut JSON::Object(ref mut object))
-            | (_, "SkippableMethod", &mut JSON::Object(ref mut object))
-            | (_, "EagerGetter", &mut JSON::Object(ref mut object))
-            | (_, "SkippableGetter", &mut JSON::Object(ref mut object))
-            | (_, "EagerSetter", &mut JSON::Object(ref mut object))
-            | (_, "SkippableSetter", &mut JSON::Object(ref mut object))
-            | (_, "EagerArrowExpression", &mut JSON::Object(ref mut object))
-            | (_, "SkippableArrowExpression", &mut JSON::Object(ref mut object))
-             => {
-                 self.remove_eager_or_skippable(object);
+            | (_, "LazyFunctionExpression", &mut JSON::Object(ref mut object))=> {
+                self.remove_function_contents(object, FunctionKind::FunctionExpression);
+            }
+            (_, "EagerFunctionDeclaration", &mut JSON::Object(ref mut object))
+            | (_, "LazyFunctionDeclaration", &mut JSON::Object(ref mut object)) => {
+                self.remove_function_contents(object, FunctionKind::FunctionDeclaration);
+            }
+            (_, "EagerMethod", &mut JSON::Object(ref mut object))
+            | (_, "LazyMethod", &mut JSON::Object(ref mut object)) => {
+                self.remove_function_contents(object, FunctionKind::Method);
+            }
+            (_, "EagerGetter", &mut JSON::Object(ref mut object))
+            | (_, "LazyGetter", &mut JSON::Object(ref mut object)) => {
+                self.remove_function_contents(object, FunctionKind::Getter);
+            }
+            (_, "EagerSetter", &mut JSON::Object(ref mut object))
+            | (_, "LazySetter", &mut JSON::Object(ref mut object)) => {
+                self.remove_function_contents(object, FunctionKind::Setter);
+            }
+            (_, "EagerArrowExpressionWithFunctionBody", &mut JSON::Object(ref mut object))
+            | (_, "LazyArrowExpressionWithFunctionBody", &mut JSON::Object(ref mut object)) => {
+                self.remove_function_contents(object, FunctionKind::ArrowExpressionWithFunctionBody);
+            }
+            (_, "EagerArrowExpressionWithExpression", &mut JSON::Object(ref mut object))
+            | (_, "LazyArrowExpressionWithExpression", &mut JSON::Object(ref mut object)) => {
+                self.remove_function_contents(object, FunctionKind::ArrowExpressionWithExpression);
             }
             _ => {
                 // Nothing to do.
@@ -477,25 +673,41 @@ fn test_shift_basic() {
     let expected = object!{
         "type" => "Script",
         "directives" => array![],
+        "scope" => object!{
+            "type" => "AssertedScriptGlobalScope",
+            "declaredNames" => array![],
+            "hasDirectEval" => false,
+        },
         "statements" => array![
             object!{
                 "type" => "EagerFunctionDeclaration",
                 "isGenerator" => false,
                 "isAsync" => false,
-                "scope" => JSON::Null,
                 "name" => object!{
                     "type" => "BindingIdentifier",
                     "name" => "foo"
                 },
-                "params" => object!{
-                    "type" => "FormalParameters",
-                    "items" => array![],
-                    "rest" => json::Null,
-                },
-                "body" => object!{
-                    "type" => "FunctionBody",
-                    "directives" => array![],
-                    "statements" => array![]
+                "directives" => array![],
+                "contents" => object!{
+                    "type" => "FunctionOrMethodContents",
+                    "isThisCaptured" => false,
+                    "parameterScope" => object!{
+                        "type" => "AssertedParameterScope",
+                        "boundNames" => array![],
+                        "hasDirectEval" => false,
+                        "isSimpleParameterList" => true,
+                    },
+                    "params" => object!{
+                        "type" => "FormalParameters",
+                        "items" => array![],
+                        "rest" => json::Null,
+                    },
+                    "bodyScope" => object!{
+                        "type" => "AssertedVarScope",
+                        "declaredNames" => array![],
+                        "hasDirectEval" => false,
+                    },
+                    "body" => array![],
                 }
             }
         ]

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -119,7 +119,7 @@ fn main() {
             'per_level: for level in &[0, 1, 2, 3, 4, 5] {
 
                 let mut ast = reference_ast.clone();
-                let mut visitor = binjs::specialized::es6::skip::LazifierVisitor::new(*level);
+                let mut visitor = binjs::specialized::es6::lazy::LazifierVisitor::new(*level);
                 ast.walk(&mut path, &mut visitor)
                     .expect("Could not introduce laziness");
                 progress();


### PR DESCRIPTION
to be clear, I don't intend do land this immediately.
discussion is here: https://github.com/orgs/binast/teams/binast-core/discussions/7

this updates the in-tree idl and corresponding parts to match to the spec at the point of Jun 28.
https://github.com/binast/ecmascript-binary-ast/commits/spec-draft

The main changes are:
 - AssertedDeclaredName/AssertedBoundName + AssertedDeclaredKind for scopes
 - Skippable interface to Lazy field
   - skip/skipped implicit fields are removed, and {fieldname}_skip field is inserted before the lazy field, which has offset
 - separate Function and Contents
 - separate ArrowExpression for FunctionBody and Expression
 - scope is no more optional
   - when converting from Shift's JSON, dummy scope object is created
 - version number is bumped