### PR TITLE
Add command-line filter mode (fixes #166) 

### DIFF
--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -142,7 +142,11 @@ impl SourceParser for Shift {
     type Error = Error;
     fn parse_str(&self, data: &str) -> Result<JSON, Error> {
         // Escape `"`.
-        let data = data.replace("\"", "\\\"");
+        let data = data
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\r", "\\r")
+            .replace("\n", "\\n");
 
         // A script to parse a string, write it to stdout as JSON.
         let script = format!(


### PR DESCRIPTION
I'm not sure how to handle patch stack on github, anyway here's the patch for command-line filter mode, on https://github.com/binast/binjs-ref/pull/167