### PR TITLE
Consolidating shared strings

### DIFF
--- a/crates/binjs_es6/src/io.rs
+++ b/crates/binjs_es6/src/io.rs
@@ -1,11 +1,11 @@
 use binjs_io::{ self, Deserialization, Guard, TokenReader, TokenReaderError, TokenWriterError };
 pub use binjs_io::{ Serialization, TokenSerializer, TokenWriter };
-use binjs_shared::{ IdentifierName, Offset, PropertyKey, SharedString, self };
+use binjs_shared::{ FieldName, IdentifierName, InterfaceName, Offset, PropertyKey, SharedString, self };
 
 use std::io::{ Read, Seek };
 
 /// A path used when (de)serializing ES6 ASTs.
-pub type IOPath = binjs_shared::ast::Path<SharedString, (/* child index */ usize, /* field name */ SharedString)>;
+pub type IOPath = binjs_shared::ast::Path<InterfaceName, (/* child index */ usize, /* field name */ FieldName)>;
 
 /// A structure used for deserialization purposes.
 pub struct Deserializer<R> where R: TokenReader {
@@ -338,3 +338,4 @@ impl Encoder {
         }
     }
 }
+

--- a/crates/binjs_io/src/entropy/mod.rs
+++ b/crates/binjs_io/src/entropy/mod.rs
@@ -63,6 +63,8 @@ pub mod write;
 use self::predict::Symbol;
 use self::tree::F64;
 
+use binjs_shared::{ IdentifierName, InterfaceName, SharedString };
+
 use std::rc::Rc;
 
 use clap;
@@ -72,11 +74,11 @@ pub type ASTPath = tree::ASTPath;
 pub type ScopePath = tree::ScopePath;
 
 pub trait EncodingModel {
-    fn tag_frequency_for_encoding(&mut self, tag: &tree::Tag, path: &ASTPath) -> Result<Symbol, ()>;
+    fn tag_frequency_for_encoding(&mut self, tag: &InterfaceName, path: &ASTPath) -> Result<Symbol, ()>;
     fn bool_frequency_for_encoding(&mut self, value: &Option<bool>, path: &ASTPath) -> Result<Symbol, ()>;
-    fn string_frequency_for_encoding(&mut self, string: &Option<Rc<String>>, path: &ASTPath) -> Result<Symbol, ()>;
+    fn string_frequency_for_encoding(&mut self, string: &Option<SharedString>, path: &ASTPath) -> Result<Symbol, ()>;
     fn number_frequency_for_encoding(&mut self, number: &Option<F64>, path: &ASTPath) -> Result<Symbol, ()>;
-    fn identifier_frequency_for_encoding(&mut self, string: &Rc<String>, scopes: &ScopePath) -> Result<Symbol, ()>;
+    fn identifier_frequency_for_encoding(&mut self, string: &IdentifierName, scopes: &ScopePath) -> Result<Symbol, ()>;
     fn list_length_frequency_for_encoding(&mut self, value: &Option<u32>, path: &ASTPath) -> Result<Symbol, ()>;
 
     /// Utility: return the frequency information for a true/false value in which

--- a/crates/binjs_io/src/entropy/model.rs
+++ b/crates/binjs_io/src/entropy/model.rs
@@ -1,7 +1,8 @@
 use entropy::{ DecodingModel, EncodingModel, Model };
 use entropy::predict::{ ContextPredict, PathPredict, Symbol };
-use entropy::tree::{ EXPECTED_PATH_DEPTH, EXPECTED_SCOPE_DEPTH, ASTPath, F64, Label, ScopeIndex, ScopePath, SharedTree, Tag, Visitor, WalkTree };
+use entropy::tree::{ EXPECTED_PATH_DEPTH, EXPECTED_SCOPE_DEPTH, ASTPath, F64, Label, ScopeIndex, ScopePath, SharedTree, Visitor, WalkTree };
 
+use binjs_shared::{ IdentifierName, InterfaceName, SharedString };
 use binjs_shared::ast::PathItem;
 
 use std;
@@ -32,10 +33,10 @@ impl ExactEncodingModel {
     }
 }
 impl EncodingModel for ExactEncodingModel {
-    fn string_frequency_for_encoding(&mut self, value: &Option<Rc<String>>, path: &ASTPath) -> Result<Symbol, ()> {
+    fn string_frequency_for_encoding(&mut self, value: &Option<SharedString>, path: &ASTPath) -> Result<Symbol, ()> {
         Self::get_from_path(&mut self.probabilities.strings, value, path)
     }
-    fn tag_frequency_for_encoding(&mut self, value: &Tag, path: &ASTPath) -> Result<Symbol, ()> {
+    fn tag_frequency_for_encoding(&mut self, value: &InterfaceName, path: &ASTPath) -> Result<Symbol, ()> {
         Self::get_from_path(&mut self.probabilities.tags, value, path)
     }
     fn bool_frequency_for_encoding(&mut self, value: &Option<bool>, path: &ASTPath) -> Result<Symbol, ()> {
@@ -52,7 +53,7 @@ impl EncodingModel for ExactEncodingModel {
             .ok_or(())?;
         Ok(segment.clone())
     }
-    fn identifier_frequency_for_encoding(&mut self, string: &Rc<String>, scopes: &ScopePath) -> Result<Symbol, ()> {
+    fn identifier_frequency_for_encoding(&mut self, string: &IdentifierName, scopes: &ScopePath) -> Result<Symbol, ()> {
         let scope = scopes.get(0)
             .map(PathItem::interface)
             .cloned();
@@ -106,10 +107,10 @@ impl ExactEncodingModel {
 
 pub struct ExactEncodingModelData<T> {
     /// Tag prediction based on path (depth 1 as of this writing).
-    tags: PathPredict<Tag, T>,
+    tags: PathPredict<InterfaceName, T>,
 
     /// Non-identifier string prediction based on path (depth 1 as of this writing).
-    strings: PathPredict<Option<Rc<String>>, T>,
+    strings: PathPredict<Option<SharedString>, T>,
 
     /// Number prediction based on path.
     numbers: PathPredict<Option<F64>, T>,
@@ -118,7 +119,7 @@ pub struct ExactEncodingModelData<T> {
     bools: PathPredict<Option<bool>, T>,
 
     /// Identifier prediction based on scope.
-    identifiers: ContextPredict<Option<ScopeIndex>, Rc<String>, T>,
+    identifiers: ContextPredict<Option<ScopeIndex>, IdentifierName, T>,
 
     /// List length prediction based on path.
     list_lengths: PathPredict<Option<u32>, T>,

--- a/crates/binjs_io/src/entropy/predict.rs
+++ b/crates/binjs_io/src/entropy/predict.rs
@@ -1,4 +1,4 @@
-use entropy::tree::{ ASTPath, ASTPathItem, Tag };
+use entropy::tree::{ ASTPath, ASTPathItem };
 
 use std;
 use std::cell::RefCell;

--- a/crates/binjs_io/src/entropy/read.rs
+++ b/crates/binjs_io/src/entropy/read.rs
@@ -1,10 +1,9 @@
 use entropy::{ ASTPath, DecodingModel, Model };
-use entropy::tree::Tag;
 
 use io::{FileStructurePrinter, TrivialGuard, TokenReader};
 use ::TokenReaderError;
 
-use binjs_shared:: { IdentifierName, PropertyKey, SharedString };
+use binjs_shared:: { FieldName, IdentifierName, InterfaceName, PropertyKey, SharedString };
 
 use range_encoding::CumulativeDistributionFrequency;
 use range_encoding::opus;
@@ -36,7 +35,7 @@ impl Decompressor {
         unimplemented!()
     }
 
-    fn tagged_tuple(&mut self, cdf: &mut CumulativeDistributionFrequency) -> Result<(SharedString, Option<Rc<Box<[String]>>>, TrivialGuard<TokenReaderError>), TokenReaderError>
+    fn tagged_tuple(&mut self, cdf: &mut CumulativeDistributionFrequency) -> Result<(InterfaceName, Option<Rc<Box<[FieldName]>>>, TrivialGuard<TokenReaderError>), TokenReaderError>
     {
         // FIXME: 1. Get the tag.
         // FIXME: 2. Update the Path.
@@ -105,7 +104,7 @@ impl<M> TokenReader for TreeTokenReader<M> where M: DecodingModel {
         unimplemented!()
     }
 
-    fn tagged_tuple(&mut self) -> Result<(SharedString, Option<Rc<Box<[String]>>>, Self::TaggedGuard), Self::Error> {
+    fn tagged_tuple(&mut self) -> Result<(InterfaceName, Option<Rc<Box<[FieldName]>>>, Self::TaggedGuard), Self::Error> {
         if let Some(cdf) = self.model.tag_frequency_for_decoding(&self.path) {
             return self.decompressor.tagged_tuple(cdf)
         }

--- a/crates/binjs_io/src/multipart/mod.rs
+++ b/crates/binjs_io/src/multipart/mod.rs
@@ -194,7 +194,7 @@ fn test_multipart_io() {
     extern crate env_logger;
     env_logger::init();
 
-    use binjs_shared::SharedString;
+    use binjs_shared::{ FieldName, InterfaceName, SharedString };
 
     use ::CompressionTarget;
     use io::{ Guard, TokenReader, TokenWriter };
@@ -326,10 +326,10 @@ fn test_multipart_io() {
             let item_0 = writer.string(Some(&SharedString::from_str("foo"))).unwrap();
             let item_1 = writer.string(Some(&SharedString::from_str("bar"))).unwrap();
             let item_2 = writer.float(Some(3.1415)).unwrap();
-            writer.tagged_tuple("some tuple", &[
-                ("abc", item_0),
-                ("def", item_1),
-                ("value", item_2)
+            writer.tagged_tuple(&InterfaceName::from_str("some tuple"), &[
+                (FieldName::from_str("abc"), item_0),
+                (FieldName::from_str("def"), item_1),
+                (FieldName::from_str("value"), item_2)
             ])
                 .expect("Writing trivial tagged tuple");
 

--- a/crates/binjs_io/src/multipart/read.rs
+++ b/crates/binjs_io/src/multipart/read.rs
@@ -14,7 +14,7 @@ use io::*;
 use multipart::{ FormatInTable, HEADER_GRAMMAR_TABLE, HEADER_STRINGS_TABLE, HEADER_TREE };
 use util::{ PoisonLock, Pos, ReadConst };
 
-use binjs_shared::SharedString;
+use binjs_shared::{ FieldName, InterfaceName, SharedString };
 
 impl Into<std::io::Error> for TokenReaderError {
     fn into(self) -> std::io::Error {
@@ -467,7 +467,7 @@ impl TokenReader for TreeTokenReader {
     /// Returns the tag name, `None` for fields and a
     /// sub-extractor dedicated
     /// to that tuple. The sub-extractor MUST be consumed entirely.
-    fn tagged_tuple(&mut self) -> Result<(SharedString, Option<Rc<Box<[String]>>>, Self::TaggedGuard), Self::Error> {
+    fn tagged_tuple(&mut self) -> Result<(InterfaceName, Option<Rc<Box<[FieldName]>>>, Self::TaggedGuard), Self::Error> {
         let clone = self.owner.clone();
         self.owner.borrow_mut().try(|state| {
             let index = state.reader.read_varnum()
@@ -475,10 +475,10 @@ impl TokenReader for TreeTokenReader {
             let description = state.grammar_table.get(index)
                 .ok_or(TokenReaderError::BadKindIndex(index))?;
 
-            let tag = description.kind.clone();
+            let tag = InterfaceName(description.kind.clone());
             let guard = SimpleGuard::new(clone);
             debug!(target: "multipart", "Reading tagged tuple with kind \"{}\"",
-                tag);
+                tag.as_shared_string());
             Ok((tag, None, guard))
         })
     }

--- a/crates/binjs_io/src/xml.rs
+++ b/crates/binjs_io/src/xml.rs
@@ -4,7 +4,7 @@
 
 use ::{ TokenWriter, TokenWriterError };
 
-use binjs_shared::SharedString;
+use binjs_shared::{ FieldName, InterfaceName, SharedString };
 
 use std::rc::Rc;
 use std::io::Write;
@@ -20,8 +20,8 @@ pub enum SubTree {
     U32(u32),
     List(Vec<Rc<SubTree>>),
     Node {
-        name: String,
-        children: Vec<(String, Rc<SubTree>)>
+        name: SharedString,
+        children: Vec<(SharedString, Rc<SubTree>)>
     },
 }
 
@@ -105,11 +105,12 @@ impl TokenWriter for Encoder {
         unimplemented!()
     }
 
-    fn tagged_tuple(&mut self, tag: &str, items: &[(&str, Self::Tree)]) -> Result<Self::Tree, TokenWriterError> {
+    fn tagged_tuple(&mut self, tag: &InterfaceName, items: &[(FieldName, Self::Tree)]) -> Result<Self::Tree, TokenWriterError> {
         self.register(SubTree::Node {
-            name: tag.to_string(),
+            name: tag.as_shared_string()
+                .clone(),
             children: items.iter().map(|(attribute, tree)| {
-                (attribute.to_string(), tree.clone())
+                (attribute.as_shared_string().clone(), tree.clone())
             }).collect()
         })
     }

--- a/crates/binjs_shared/src/lib.rs
+++ b/crates/binjs_shared/src/lib.rs
@@ -26,57 +26,18 @@ pub enum VisitMe<T> {
     DoneHere,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct IdentifierName(pub SharedString);
+/// An identifier, inside the grammar.
+shared_string!(pub IdentifierName);
 pub type Identifier = IdentifierName;
-impl IdentifierName {
-    pub fn from_str(value: &'static str) -> Self {
-        IdentifierName(SharedString::from_str(value))
-    }
-    pub fn from_string(value: String) -> Self {
-        IdentifierName(SharedString::from_string(value))
-    }
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-    pub fn as_shared_string(&self) -> &SharedString {
-        &self.0
-    }
-}
-impl<'a> PartialEq<&'a str> for IdentifierName {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0.eq(other)
-    }
-}
-impl Default for IdentifierName {
-    fn default() -> Self {
-        Self::from_str("<uninitialized IdentifierName>")
-    }
-}
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct PropertyKey(pub SharedString);
-impl PropertyKey {
-    pub fn from_str(value: &'static str) -> Self {
-        PropertyKey(SharedString::from_str(value))
-    }
-    pub fn from_string(value: String) -> Self {
-        PropertyKey(SharedString::from_string(value))
-    }
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-    pub fn as_shared_string(&self) -> &SharedString {
-        &self.0
-    }
-}
-impl<'a> PartialEq<&'a str> for PropertyKey {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0.eq(other)
-    }
-}
-impl Default for PropertyKey {
-    fn default() -> Self {
-        Self::from_str("<uninitialized PropertyKey>")
-    }
-}
+/// A property, inside the grammar.
+shared_string!(pub PropertyKey);
+
+/// An interface *of* the grammar.
+shared_string!(pub InterfaceName);
+
+/// A field name *of* the grammar.
+shared_string!(pub FieldName);
+
+
+

--- a/crates/binjs_shared/src/shared_string.rs
+++ b/crates/binjs_shared/src/shared_string.rs
@@ -71,3 +71,35 @@ impl SharedString {
         SharedString::Dynamic(Rc::new(value))
     }
 }
+
+#[macro_export]
+macro_rules! shared_string {
+    (pub $name: ident) => {
+        #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+        pub struct $name(pub shared_string::SharedString);
+        impl $name {
+            pub fn from_str(value: &'static str) -> Self {
+                $name(shared_string::SharedString::from_str(value))
+            }
+            pub fn from_string(value: String) -> Self {
+                $name(shared_string::SharedString::from_string(value))
+            }
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
+            }
+            pub fn as_shared_string(&self) -> &shared_string::SharedString {
+                &self.0
+            }
+        }
+        impl<'a> PartialEq<&'a str> for $name {
+            fn eq(&self, other: &&'a str) -> bool {
+                self.0.eq(other)
+            }
+        }
+        impl Default for $name {
+            fn default() -> Self {
+                Self::from_str("<uninitialized SharedString>")
+            }
+        }
+    }
+}


### PR DESCRIPTION
More work on using `SharedString` everywhere and avoiding copies.