### PR TITLE
Order table entries with same number of use by data itself (fixes #171)

### DIFF
--- a/crates/binjs_io/src/multipart/write.rs
+++ b/crates/binjs_io/src/multipart/write.rs
@@ -97,7 +97,7 @@ impl Serializable for Option<SharedString> {
 /// An entry in an WriterTable.
 ///
 /// This entry tracks the number of instances of the entry used in the table.
-struct TableEntry<T> where T: Clone + std::fmt::Debug { // We shouldn't need the `Clone`, sigh.
+struct TableEntry<T> where T: Clone + std::fmt::Debug + Ord { // We shouldn't need the `Clone`, sigh.
     /// Number of instances of this entry around.
     instances: RefCell<u32>,
 
@@ -107,7 +107,7 @@ struct TableEntry<T> where T: Clone + std::fmt::Debug { // We shouldn't need the
     /// The index, actually computed in `write()`.
     index: TableIndex<T>
 }
-impl<T> TableEntry<T> where T: Clone + std::fmt::Debug {
+impl<T> TableEntry<T> where T: Clone + std::fmt::Debug + Ord {
     fn new(data: T) -> Self {
         TableEntry {
             instances: RefCell::new(1),
@@ -116,13 +116,31 @@ impl<T> TableEntry<T> where T: Clone + std::fmt::Debug {
         }
     }
 }
+impl<T> PartialEq for TableEntry<T> where T: Clone + std::fmt::Debug + Ord {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+impl<T> Eq for TableEntry<T> where T: Clone + std::fmt::Debug + Ord {
+}
+impl<T> PartialOrd for TableEntry<T> where T: Clone + std::fmt::Debug + Ord {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<T> Ord for TableEntry<T> where T: Clone + std::fmt::Debug + Ord {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        u32::cmp(&*other.instances.borrow(), &*self.instances.borrow())
+            .then_with(|| self.data.cmp(&other.data))
+    }
+}
 
 /// A table, used to define a varnum-indexed header
-struct WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug {
+struct WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug + Ord {
     map: HashMap<Entry, TableEntry<Entry>>
 }
 
-impl<Entry> WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug {
+impl<Entry> WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug + Ord {
     pub fn new() -> Self {
         WriterTable {
             map: HashMap::new()
@@ -131,7 +149,7 @@ impl<Entry> WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + F
 }
 
 
-impl<Entry> WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug {
+impl<Entry> WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug + Ord {
     /// Get an entry from the header.
     ///
     /// The number of entries is incremented by 1.
@@ -173,13 +191,13 @@ impl<Entry> WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + F
 ///       -   byte length of entry (varnum);
 /// - for each entry,
 /// -   serialization of entry.
-impl<Entry> Serializable for WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug {
+impl<Entry> Serializable for WriterTable<Entry> where Entry: Eq + Hash + Clone + Serializable + FormatInTable + Debug + Ord {
     fn write<W: Write>(&self, out: &mut W) -> Result<usize, std::io::Error> {
         let mut total = 0;
 
-        // Sort entries by number of uses.
+        // Sort entries by number of uses and entry data specific ordering
         let mut contents : Vec<_> = self.map.values().collect();
-        contents.sort_unstable_by(|a, b| u32::cmp(&*b.instances.borrow(), &*a.instances.borrow()));
+        contents.sort_unstable();
 
         // Assign TableIndex
         for i in 0..contents.len() {
@@ -221,7 +239,7 @@ impl<Entry> Serializable for WriterTable<Entry> where Entry: Eq + Hash + Clone +
 }
 
 
-#[derive(PartialEq, Eq, Clone, Hash, Debug)] // FIXME: Clone shouldn't be necessary. Sigh.
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Hash, Debug)] // FIXME: Clone shouldn't be necessary. Sigh.
 pub struct NodeDescription {
     kind: SharedString,
 }


### PR DESCRIPTION
Defined the order between the table entries with the same number of uses,
so that the order between them is fixed in the file