### PR TITLE
Fix advanced subsubcommand (fixes #178)

### DIFF
--- a/examples/compare_compression.rs
+++ b/examples/compare_compression.rs
@@ -94,8 +94,6 @@ fn get_compressed_sizes(path: &std::path::Path) -> Sizes {
 
 fn main() {
     env_logger::init();
-    let format_providers = binjs::io::Format::providers();
-
     let dest_path_binjs = "/tmp/binjs-test.js.binjs";
 
     let matches = App::new("Compare BinJS compression and brotli/gzip compression")
@@ -109,9 +107,7 @@ fn main() {
                 .takes_value(true)
                 .help("Glob path towards source files"),
         ])
-        .subcommands(format_providers.iter()
-            .map(|x| x.subcommand())
-        )
+        .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
     let mut format = binjs::io::Format::from_matches(&matches)

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -21,8 +21,6 @@ use std::io::Write;
 fn main() {
     env_logger::init();
 
-    let format_providers = binjs::io::Format::providers();
-
     let matches = App::new("BinJS source file generator")
         .author("David Teller <dteller@mozilla.com>")
         .about(
@@ -46,11 +44,7 @@ Note that this tool does not attempt to make sure that the files are entirely co
                 .long("random-metadata")
                 .help("If specified, generate random ast metadata (declared variables, etc.).")
         ])
-        .subcommand(SubCommand::with_name("advanced")
-            .subcommands(format_providers.iter()
-                .map(|x| x.subcommand())
-            )
-        )
+        .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
     let mut rng = rand::thread_rng();

--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -14,8 +14,6 @@ use std::io::*;
 fn main() {
     env_logger::init();
 
-    let format_providers = binjs::io::Format::providers();
-
     let matches = App::new("BinJS roundtrip tester")
         .author("David Teller, <dteller@mozilla.com>")
         .about("Check that encoding + decoding a file yields the same AST.")
@@ -42,9 +40,7 @@ fn main() {
                     .map_err(|e| format!("Invalid number {}", e)))
                 .help("Number of layers of functions to lazify. 0 = no lazification, 1 = functions at toplevel, 2 = also functions in functions at toplevel, etc."),
         ])
-        .subcommands(format_providers.iter()
-            .map(|x| x.subcommand())
-        )
+        .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
     let mut format = binjs::io::Format::from_matches(&matches)

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -216,8 +216,6 @@ fn main() {
 fn main_aux() {
     env_logger::init();
 
-    let format_providers = binjs::io::Format::providers();
-
     let matches = App::new("BinJS encoder")
         .author("David Teller, <dteller@mozilla.com>")
         .about("Encode a JavaScript text source to a JavaScript binary source in the BinJS format.")
@@ -252,11 +250,7 @@ fn main_aux() {
                 .short("q")
                 .help("Do not print progress"),
         ])
-        .subcommand(SubCommand::with_name("advanced")
-            .subcommands(format_providers.iter()
-                .map(|x| x.subcommand())
-            )
-        )
+        .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
     // Common options.


### PR DESCRIPTION
given prividers are subsubcommand, we should first check the `advanced` subcommand there and check against `matches` for the subcommand.