### PR TITLE
Add weird bytes to container header

### DIFF
--- a/crates/binjs_io/src/multipart/read.rs
+++ b/crates/binjs_io/src/multipart/read.rs
@@ -232,11 +232,15 @@ pub struct TreeTokenReader {
 impl TreeTokenReader {
     pub fn new<R: Read + Seek>(mut reader: R) -> Result<Self, TokenReaderError> {
         // Check magic headers.
-        const MAGIC_HEADER: &'static [u8; 5] = b"BINJS";
+        const MAGIC_HEADER: &'static [u8; 8] = b"\x89BJS\r\n\0\n";
+        const OLD_MAGIC_HEADER: &'static [u8; 5] = b"BINJS";
         const FORMAT_VERSION: u32 = 1;
 
-        reader.read_const(MAGIC_HEADER)
-            .map_err(TokenReaderError::ReadError)?;
+        if let Err(e) = reader.read_const(MAGIC_HEADER)
+            .map_err(TokenReaderError::ReadError) {
+                reader.read_const(OLD_MAGIC_HEADER)
+                    .map_err(TokenReaderError::ReadError)?;
+        }
 
         let version = reader.read_varnum()
             .map_err(TokenReaderError::ReadError)?;

--- a/crates/binjs_io/src/multipart/write.rs
+++ b/crates/binjs_io/src/multipart/write.rs
@@ -543,7 +543,7 @@ impl TreeTokenWriter {
     }
 
     pub fn done(mut self) -> Result<(Box<[u8]>, Statistics), TokenWriterError> {
-        const MAGIC_HEADER: &[u8; 5] = b"\x89BJS\r\n\0\n";
+        const MAGIC_HEADER: &[u8; 8] = b"\x89BJS\r\n\0\n";
         // Write header to byte stream
         self.data.write_all(MAGIC_HEADER)
             .map_err(TokenWriterError::WriteError)?;

--- a/crates/binjs_io/src/multipart/write.rs
+++ b/crates/binjs_io/src/multipart/write.rs
@@ -543,7 +543,7 @@ impl TreeTokenWriter {
     }
 
     pub fn done(mut self) -> Result<(Box<[u8]>, Statistics), TokenWriterError> {
-        const MAGIC_HEADER: &[u8; 5] = b"BINJS";
+        const MAGIC_HEADER: &[u8; 5] = b"\x89BJS\r\n\0\n";
         // Write header to byte stream
         self.data.write_all(MAGIC_HEADER)
             .map_err(TokenWriterError::WriteError)?;


### PR DESCRIPTION
Changes the stamp at the the beginning of BinAST files to one based on the PNG header.
This is done to make it play nicer when used with software that does text processing:

* Because the stamp contains a NUL byte, most software (particularly Git) will recognize that it is not a text file. The header is also not valid UTF-8, in case any software tries to check text validity that way.
* Because the stamp contains a UNIX newline and a DOS newline, anything that unconditionally performs line conversion will be detected right away.

Fixes #196