### PR TITLE
Use {enter,exit}_* in and remove Guard from TokenReader.

### DIFF
--- a/crates/binjs_es6/src/io.rs
+++ b/crates/binjs_es6/src/io.rs
@@ -1,4 +1,4 @@
-use binjs_io::{ self, Deserialization, Guard, TokenReader, TokenReaderError, TokenWriterTreeAdapter, TokenWriterError };
+use binjs_io::{ self, Deserialization, TokenReader, TokenReaderError, TokenWriterTreeAdapter, TokenWriterError };
 pub use binjs_io::{ Serialization, TokenSerializer, TokenWriter };
 use binjs_shared::{ FieldName, IdentifierName, InterfaceName, Offset, PropertyKey, SharedString, self };
 
@@ -99,7 +99,7 @@ impl<R> Deserialization<R, Option<PropertyKey>> for Deserializer<R> where R: Tok
 
 impl<R, T> Deserialization<R, Vec<T>> for Deserializer<R> where R: TokenReader, Self: Deserialization<R, T> {
     fn deserialize(&mut self, path: &mut IOPath) -> Result<Vec<T>, TokenReaderError> {
-        let (len, guard) = self.reader.list_at(path)?;
+        let len = self.reader.enter_list_at(path)?;
         if len > 0 {
             print_file_structure!(self.reader, "list (length={}) [", len);
         } else {
@@ -112,7 +112,7 @@ impl<R, T> Deserialization<R, Vec<T>> for Deserializer<R> where R: TokenReader, 
         if len > 0 {
             print_file_structure!(self.reader, "]");
         }
-        guard.done()?;
+        self.reader.exit_list_at(path)?;
         Ok(result)
     }
 }

--- a/crates/binjs_generate_library/src/lib.rs
+++ b/crates/binjs_generate_library/src/lib.rs
@@ -124,7 +124,7 @@ impl RustExporter {
         ast_buffer.push_str("
 use binjs_shared;
 use binjs_shared::{ FieldName, FromJSON, FromJSONError, IdentifierName, InterfaceName, Offset, PropertyKey, SharedString, ToJSON, VisitMe };
-use binjs_io::{ Deserialization, Guard, InnerDeserialization, Serialization, TokenReader, TokenReaderError, TokenWriter, TokenWriterError };
+use binjs_io::{ Deserialization, InnerDeserialization, Serialization, TokenReader, TokenReaderError, TokenWriter, TokenWriterError };
 
 use io::*;
 
@@ -468,7 +468,7 @@ impl Default for {name} {{
 impl<R> Deserialization<R, {name}> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<{name}, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing sum {name}\");
-        let (kind, _, guard) = self.reader.tagged_tuple_at(path)?;
+        let (kind, _) = self.reader.enter_tagged_tuple_at(path)?;
         debug!(target: \"deserialize_es6\", \"Deserializing sum {name}, found {{}}\", kind.as_str());
         let path_interface = kind.clone();
         let result = match kind.as_str() {{
@@ -481,14 +481,14 @@ impl<R> Deserialization<R, {name}> for Deserializer<R> where R: TokenReader {{
         if result.is_err() {{
             self.reader.poison();
         }}
-        guard.done()?;
+        self.reader.exit_tagged_tuple_at(path)?;
         result
     }}
 }}
 impl<R> Deserialization<R, Option<{name}>> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<Option<{name}>, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing optional sum {name}\");
-        let (kind, _, guard) = self.reader.tagged_tuple_at(path)?;
+        let (kind, _) = self.reader.enter_tagged_tuple_at(path)?;
         let path_interface = kind.clone();
         let result = match kind.as_str() {{
 {variants_some}
@@ -501,7 +501,7 @@ impl<R> Deserialization<R, Option<{name}>> for Deserializer<R> where R: TokenRea
         if result.is_err() {{
             self.reader.poison();
         }}
-        guard.done()?;
+        self.reader.exit_tagged_tuple_at(path)?;
         result
     }}
 }}
@@ -983,7 +983,7 @@ pub struct {rust_name} {{
                 let from_reader = format!("
 impl<R> Deserializer<R> where R: TokenReader {{
     fn deserialize_tuple_{lowercase_name}(&mut self, path: &mut IOPath) -> Result<{rust_name}, TokenReaderError> where R: TokenReader {{
-        let (interface_name, _, guard) = self.reader.tagged_tuple_at(path)?;
+        let (interface_name, _) = self.reader.enter_tagged_tuple_at(path)?;
         let result =
             if let \"{name}\" = interface_name.as_str() {{
                 debug!(target: \"deserialize_es6\", \"Deserializing tagged tuple {name}: present\");
@@ -1000,7 +1000,7 @@ impl<R> Deserializer<R> where R: TokenReader {{
             self.reader.poison();
         }}
         debug!(target: \"deserialize_es6\", \"Deserializing tagged tuple {name}: finalizing\");
-        guard.done()?;
+        self.reader.exit_tagged_tuple_at(path)?;
         debug!(target: \"deserialize_es6\", \"Deserializing tagged tuple {name}: done\");
         result
     }}
@@ -1027,7 +1027,7 @@ impl<R> Deserialization<R, {rust_name}> for Deserializer<R> where R: TokenReader
 impl<R> Deserialization<R, Option<{rust_name}>> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<Option<{rust_name}>, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing optional tuple {rust_name}\");
-        let (kind, _, guard) = self.reader.tagged_tuple_at(path)?;
+        let (kind, _) = self.reader.enter_tagged_tuple_at(path)?;
         let result = match kind.as_str() {{
             \"{rust_name}\" => {{
                 let path_interface = kind.clone();
@@ -1050,7 +1050,7 @@ impl<R> Deserialization<R, Option<{rust_name}>> for Deserializer<R> where R: Tok
         if result.is_err() {{
             self.reader.poison();
         }}
-        guard.done()?;
+        self.reader.exit_tagged_tuple_at(path)?;
         result
     }}
 }}

--- a/crates/binjs_io/src/entropy/read.rs
+++ b/crates/binjs_io/src/entropy/read.rs
@@ -2,7 +2,7 @@
 use super::probabilities::SymbolIndex;
 
 use ::TokenReaderError;
-use ::io::{ FileStructurePrinter, Path, TokenReader, TrivialGuard };
+use ::io::{ FileStructurePrinter, Path, TokenReader };
 
 use binjs_shared::{ F64, FieldName, IdentifierName, InterfaceName, PropertyKey, SharedString };
 
@@ -73,10 +73,6 @@ macro_rules! symbol {
 }
 
 impl<R: Read> TokenReader for Decoder<R> {
-    type ListGuard = TrivialGuard;
-    type TaggedGuard = TrivialGuard;
-    type UntaggedGuard = TrivialGuard;
-
     // ---- String types
 
     fn string_at(&mut self, path: &Path) -> Result<Option<SharedString>, TokenReaderError> {
@@ -118,19 +114,19 @@ impl<R: Read> TokenReader for Decoder<R> {
 
     // ---- Composed types
 
-    fn list_at(&mut self, path: &Path) -> Result<(u32, Self::ListGuard), TokenReaderError> {
+    fn enter_list_at(&mut self, path: &Path) -> Result<u32, TokenReaderError> {
         let length = symbol!(self, list_length_by_path, "list_length_by_path", path)?
             .ok_or_else(|| TokenReaderError::EmptyList)?;
             // For the moment, we cannot read an optional list.
-        Ok((length, TrivialGuard::new()))
+        Ok(length)
     }
 
-    fn tagged_tuple_at(&mut self, path: &Path) -> Result<(InterfaceName, Option<std::rc::Rc<Box<[FieldName]>>>, Self::TaggedGuard), TokenReaderError> {
+    fn enter_tagged_tuple_at(&mut self, path: &Path) -> Result<(InterfaceName, Option<std::rc::Rc<Box<[FieldName]>>>), TokenReaderError> {
         let name = symbol!(self, interface_name_by_path, "interface_name_by_path", path)?;
-        Ok((name, None, TrivialGuard::new()))
+        Ok((name, None))
     }
 
-    fn untagged_tuple_at(&mut self, _path: &Path) -> Result<Self::UntaggedGuard, TokenReaderError> {
+    fn enter_untagged_tuple_at(&mut self, _path: &Path) -> Result<(), TokenReaderError> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
(possibly conflict with some changes in other PR)

having separate struct to track the end of list/tuple is hard to manage, because of ownership,
and I think just introducing enter/leave is sufficient for existing case.

Removed Guard structs/traits, and replaced it with {enter,leave}_{list,tagged_tuple,untagged_tuple}_at.

let me know entropy is going to introduce another guard and it conflicts with this.

will ask review after test.