### PR TITLE
Add JSON reader/writer and binjs_convert_from_json command (fixes #194)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ name = "binjs_dump"
 path = "src/bin/dump.rs"
 
 [[bin]]
+# Convert a BinAST JSON file to other BinAST file.
+name = "binjs_convert_from_json"
+path = "src/bin/convert_from_json.rs"
+
+[[bin]]
 # From a sample of JS source files, extract the distribution
 # of probabilities for all ASTs, write this distribution to
 # disk. The distribution may then be reused by binjs_encode

--- a/crates/binjs_es6/src/io.rs
+++ b/crates/binjs_es6/src/io.rs
@@ -407,6 +407,8 @@ impl Decoder {
             Deserialization<binjs_io::simple::TreeTokenReader<R>, AST>,
         Deserializer<binjs_io::multipart::TreeTokenReader>:
             Deserialization<binjs_io::multipart::TreeTokenReader, AST>,
+        Deserializer<binjs_io::json::read::Decoder<R>>:
+            Deserialization<binjs_io::json::read::Decoder<R>, AST>,
         Deserializer<binjs_io::entropy::read::Decoder<R>>:
             Deserialization<binjs_io::entropy::read::Decoder<R>, AST>,
     {
@@ -420,6 +422,12 @@ impl Decoder {
             }
             binjs_io::Format::Multipart { .. } => {
                 let reader = binjs_io::multipart::TreeTokenReader::new(source)?;
+                let mut deserializer = Deserializer::new(reader);
+                let ast = deserializer.deserialize(&mut path)?;
+                Ok(ast)
+            }
+            binjs_io::Format::JSON { .. } => {
+                let reader = binjs_io::json::read::Decoder::new(source)?;
                 let mut deserializer = Deserializer::new(reader);
                 let ast = deserializer.deserialize(&mut path)?;
                 Ok(ast)
@@ -451,6 +459,8 @@ impl Encoder {
             Serialization<TokenWriterTreeAdapter<binjs_io::multipart::TreeTokenWriter>, &'a AST>,
         Serializer<TokenWriterTreeAdapter<binjs_io::xml::Encoder>>:
             Serialization<TokenWriterTreeAdapter<binjs_io::xml::Encoder>, &'a AST>,
+        Serializer<binjs_io::json::write::TreeTokenWriter>:
+            Serialization<binjs_io::json::write::TreeTokenWriter, &'a AST>,
         Serializer<binjs_io::entropy::write::Encoder>:
             Serialization<binjs_io::entropy::write::Encoder, &'a AST>,
     {
@@ -476,6 +486,13 @@ impl Encoder {
             binjs_io::Format::XML => {
                 let writer = binjs_io::xml::Encoder::new();
                 let mut serializer = Serializer::new(TokenWriterTreeAdapter::new(writer));
+                serializer.serialize(ast, &mut path)?;
+                let data = serializer.done()?;
+                Ok(Box::new(data))
+            }
+            binjs_io::Format::JSON => {
+                let writer = binjs_io::json::write::TreeTokenWriter::new();
+                let mut serializer = Serializer::new(writer);
                 serializer.serialize(ast, &mut path)?;
                 let data = serializer.done()?;
                 Ok(Box::new(data))

--- a/crates/binjs_io/src/json/mod.rs
+++ b/crates/binjs_io/src/json/mod.rs
@@ -1,0 +1,34 @@
+//! A format for generating invalid file, to test decoder implementation.
+//!
+//! The expected usage is the following:
+//!
+//!   1. Convert .js file to this JSON format (write module)
+//!   2. Modify the JSON file
+//!   3. Convert JSON file to other BinAST format (parser, read modules)
+//!   4. Feed the possibly-invalid BinAST to decoder
+
+mod parser;
+
+mod value;
+
+pub mod read;
+
+pub mod write;
+
+use clap;
+
+/// Command-line management.
+pub struct FormatProvider;
+impl ::FormatProvider for FormatProvider {
+    fn subcommand<'a, 'b>(&self) -> clap::App<'a, 'b> {
+        use clap::*;
+        SubCommand::with_name("json").about("Encode to json. This is for testing purpose only.")
+    }
+
+    fn handle_subcommand(
+        &self,
+        _matches: Option<&clap::ArgMatches>,
+    ) -> Result<::Format, ::std::io::Error> {
+        Ok(::Format::JSON)
+    }
+}

--- a/crates/binjs_io/src/json/parser.rs
+++ b/crates/binjs_io/src/json/parser.rs
@@ -1,0 +1,752 @@
+/// JSON parser.
+/// This is manual translation of the JSONParser class in:
+///   https://hg.mozilla.org/mozilla-central/file/tip/js/src/vm/JSONParser.cpp
+///   https://hg.mozilla.org/mozilla-central/file/tip/js/src/vm/JSONParser.h
+use TokenReaderError;
+
+use binjs_shared::SharedString;
+
+use super::value::Value;
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::rc::Rc;
+
+use escaped_wtf8;
+
+/// Token read by Parser::advance* methods.
+///
+/// Converted from JSONParserBase::Token.
+enum Token {
+    String(SharedString),
+    Number(f64),
+    True,
+    False,
+    Null,
+    ArrayOpen,
+    ArrayClose,
+    ObjectOpen,
+    ObjectClose,
+    Colon,
+    Comma,
+}
+
+/// Property item inside object.
+/// This struct is used while parsing, and when a single object is parsed,
+/// the list of Property is converted to HashMap for Value::Object.
+struct Property {
+    /// Property key.
+    key: SharedString,
+
+    /// Property value.
+    value: Rc<Value>,
+}
+
+/// Possible states the parser can be in between values.
+///
+/// Converted from JSONParserBase::{ParserState, StackEntry}.
+enum State {
+    /// Parsing an object.
+    /// Each property is pushed to the vector.
+    FinishObjectMember(Vec<Property>),
+
+    /// Parsing an array.
+    /// Each element is pushed to the vector.
+    FinishArrayElement(Vec<Rc<Value>>),
+
+    /// At the start of the parse, before any values have been processed.
+    JSONValue,
+}
+
+/// The state of the next iteration, with value from previous iteration.
+struct NextState {
+    /// The value parsed in the previous iteration.
+    prev_value: Rc<Value>,
+
+    /// The state of the next iteration.
+    state: State,
+}
+
+/// The label of goto used in JSONParser:::parse.
+enum NextLabel {
+    /// An object property value has just been parsed.
+    FinishObjectMember,
+
+    /// At the start of parsing an object property.
+    JSONMember(Token),
+
+    /// An array element has just being parsed.
+    FinishArrayElement,
+
+    /// At the start of the parse, before any values have been processed.
+    JSONValue,
+
+    /// After reading a token for any value.
+    JSONValueSwitch(Token),
+}
+
+/// No-op function just for readability.
+/// Designates goto in the original code.
+fn goto(label: NextLabel) -> NextLabel {
+    label
+}
+
+/// JSON Parser.
+///
+/// Converted from JSONParser.
+pub struct Parser<R: Read> {
+    /// Input source.
+    source: R,
+
+    /// Current UTF-8 code unit.
+    current: u8,
+
+    /// True if the source hits EOF.
+    is_eof: bool,
+
+    /// State stack.
+    stack: Vec<State>,
+}
+impl<R: Read> Parser<R> {
+    pub fn new(source: R) -> Self {
+        Parser {
+            source,
+            current: 0,
+            is_eof: false,
+            stack: Vec::new(),
+        }
+    }
+
+    /// Read a byte from the stream and store the result to `self.current`.
+    /// Returns `true` if it successfully read, and `false` is it reaches EOF.
+    fn advance_char(&mut self) -> Result<bool, TokenReaderError> {
+        if self.is_eof {
+            return Ok(false);
+        }
+
+        let mut buf = [0; 1];
+
+        let size = self
+            .source
+            .read(&mut buf)
+            .map_err(TokenReaderError::ReadError)?;
+        if size == 0 {
+            self.is_eof = true;
+            return Ok(false);
+        }
+        self.current = buf[0];
+        Ok(true)
+    }
+
+    /// Read a byte and checks if it matches to `expected`.
+    fn match_keyword_part(&mut self, expected: u8) -> Result<(), TokenReaderError> {
+        if !self.advance_char()? {
+            return Err(TokenReaderError::GenericError(
+                "unexpected keyword".to_string(),
+            ));
+        }
+        if self.current != expected {
+            return Err(TokenReaderError::GenericError(
+                "unexpected keyword".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Read a string from stream.
+    ///
+    /// Corresponds to JSONParser::readString, but not direct conversion,
+    /// because of WTF-8 handling.
+    fn read_string(&mut self) -> Result<Token, TokenReaderError> {
+        debug_assert!(self.current == b'"');
+
+        // Escape sequences are parsed in escaped_wtf8.
+        // Just read until the end of string.
+
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.push(self.current);
+        loop {
+            if !self.advance_char()? {
+                return Err(TokenReaderError::GenericError(
+                    "unterminated string".to_string(),
+                ));
+            }
+
+            match self.current {
+                b'"' => {
+                    buffer.push(self.current);
+                    self.advance_char()?;
+                    break;
+                }
+                b'\\' => {
+                    // Minimum handling of escape sequence.
+                    // Read the next unit here to ignore '"' there.
+                    buffer.push(self.current);
+                    if !self.advance_char()? {
+                        return Err(TokenReaderError::GenericError(
+                            "bad escaped character".to_string(),
+                        ));
+                    }
+                    buffer.push(self.current);
+                }
+                _ => {
+                    buffer.push(self.current);
+                }
+            }
+        }
+
+        let s = SharedString::from_string(
+            String::from_utf8(buffer).expect("Escaped string should be valid UTF-8"),
+        );
+        let decoded = escaped_wtf8::from_json(&s)
+            .map_err(|_| TokenReaderError::GenericError("bad escaped character".to_string()))?;
+        Ok(Token::String(decoded))
+    }
+
+    /// Read a number from stream.
+    ///
+    /// Converted from JSONParser::readNumber.
+    fn read_number(&mut self) -> Result<Token, TokenReaderError> {
+        // JSONNumber:
+        //   /^-?(0|[1-9][0-9]+)(\.[0-9]+)?([eE][\+\-]?[0-9]+)?$/
+
+        let negative = self.current == b'-';
+
+        let mut buffer = String::new();
+
+        // -?
+        if negative {
+            buffer.push(self.current as char);
+            if !self.advance_char()? {
+                return Err(TokenReaderError::GenericError(
+                    "no number after minus sign".to_string(),
+                ));
+            }
+        }
+
+        // 0|[1-9][0-9]+
+        if !Self::is_ascii_digit(self.current) {
+            return Err(TokenReaderError::GenericError(
+                "unexpected non-digit".to_string(),
+            ));
+        }
+        buffer.push(self.current as char);
+
+        if self.current != b'0' {
+            loop {
+                if !self.advance_char()? {
+                    let d = buffer
+                        .as_str()
+                        .parse::<f64>()
+                        .expect("should be valid number");
+                    return Ok(Token::Number(if negative { -d } else { d }));
+                }
+                if !Self::is_ascii_digit(self.current) {
+                    break;
+                }
+                buffer.push(self.current as char);
+            }
+        };
+
+        // Fast path: no fractional or exponent part.
+        if self.current != b'.' && self.current != b'e' && self.current != b'E' {
+            let d = buffer
+                .as_str()
+                .parse::<f64>()
+                .expect("should be valid number");
+            return Ok(Token::Number(if negative { -d } else { d }));
+        }
+
+        // (\.[0-9]+)?
+        if self.current == b'.' {
+            buffer.push(self.current as char);
+
+            if !self.advance_char()? {
+                return Err(TokenReaderError::GenericError(
+                    "missing digits after decimal point".to_string(),
+                ));
+            }
+            if !Self::is_ascii_digit(self.current) {
+                return Err(TokenReaderError::GenericError(
+                    "unterminated fractional number".to_string(),
+                ));
+            }
+            buffer.push(self.current as char);
+
+            loop {
+                if !self.advance_char()? {
+                    let d = buffer
+                        .as_str()
+                        .parse::<f64>()
+                        .expect("should be valid number");
+                    return Ok(Token::Number(if negative { -d } else { d }));
+                }
+                if !Self::is_ascii_digit(self.current) {
+                    break;
+                }
+                buffer.push(self.current as char);
+            }
+        }
+
+        // ([eE][\+\-]?[0-9]+)?
+        if self.current == b'e' || self.current == b'E' {
+            if !self.advance_char()? {
+                return Err(TokenReaderError::GenericError(
+                    "missing digits after exponent indicator".to_string(),
+                ));
+            }
+            if self.current == b'+' || self.current == b'-' {
+                buffer.push(self.current as char);
+
+                if !self.advance_char()? {
+                    return Err(TokenReaderError::GenericError(
+                        "missing digits after exponent sign".to_string(),
+                    ));
+                }
+            }
+            if !Self::is_ascii_digit(self.current) {
+                return Err(TokenReaderError::GenericError(
+                    "exponent part is missing a number".to_string(),
+                ));
+            }
+            buffer.push(self.current as char);
+
+            loop {
+                if !self.advance_char()? {
+                    break;
+                }
+                if !Self::is_ascii_digit(self.current) {
+                    break;
+                }
+                buffer.push(self.current as char);
+            }
+        }
+
+        let d = buffer
+            .as_str()
+            .parse::<f64>()
+            .expect("should be valid number");
+        Ok(Token::Number(if negative { -d } else { d }))
+    }
+
+    /// Returns true if the given code unit is whitespace.
+    ///
+    /// Converted from IsJSONWhitespace.
+    fn is_json_whitespace(c: u8) -> bool {
+        return c == b'\t' || c == b'\r' || c == b'\n' || c == b' ';
+    }
+
+    /// Returns true if the given code unit is ASCII decimal digit.
+    ///
+    /// Converted from mozilla::IsAsciiDigit.
+    fn is_ascii_digit(c: u8) -> bool {
+        return b'0' <= c && c <= b'9';
+    }
+
+    /// Read bytes from stream until it find non-whitespace.
+    /// Returns `true` if it successfully found non-whitespace, and `false` is
+    /// it reaches EOF.
+    ///
+    /// Corresponds to the beginning of JSONParser::advance* methods.
+    fn skip_whitespace(&mut self) -> Result<bool, TokenReaderError> {
+        loop {
+            if !Self::is_json_whitespace(self.current) {
+                return Ok(true);
+            }
+            if !self.advance_char()? {
+                return Ok(false);
+            }
+        }
+    }
+
+    /// Read a token.
+    ///
+    /// Converted from JSONParser::advance.
+    fn advance(&mut self) -> Result<Token, TokenReaderError> {
+        if !self.skip_whitespace()? {
+            return Err(TokenReaderError::GenericError(
+                "unexpected end of data".to_string(),
+            ));
+        }
+
+        match self.current {
+            b'"' => self.read_string(),
+            b'-' | b'0' | b'1' | b'2' | b'3' | b'4' | b'5' | b'6' | b'7' | b'8' | b'9' => {
+                self.read_number()
+            }
+            b't' => {
+                self.match_keyword_part(b'r')?;
+                self.match_keyword_part(b'u')?;
+                self.match_keyword_part(b'e')?;
+                self.advance_char()?;
+                Ok(Token::True)
+            }
+            b'f' => {
+                self.match_keyword_part(b'a')?;
+                self.match_keyword_part(b'l')?;
+                self.match_keyword_part(b's')?;
+                self.match_keyword_part(b'e')?;
+                self.advance_char()?;
+                Ok(Token::False)
+            }
+            b'n' => {
+                self.match_keyword_part(b'u')?;
+                self.match_keyword_part(b'l')?;
+                self.match_keyword_part(b'l')?;
+                self.advance_char()?;
+                Ok(Token::Null)
+            }
+            b'[' => {
+                self.advance_char()?;
+                Ok(Token::ArrayOpen)
+            }
+            b']' => {
+                self.advance_char()?;
+                Ok(Token::ArrayClose)
+            }
+            b'{' => {
+                self.advance_char()?;
+                Ok(Token::ObjectOpen)
+            }
+            b'}' => {
+                self.advance_char()?;
+                Ok(Token::ObjectClose)
+            }
+            b',' => {
+                self.advance_char()?;
+                Ok(Token::Comma)
+            }
+            b':' => {
+                self.advance_char()?;
+                Ok(Token::Colon)
+            }
+            _ => Err(TokenReaderError::GenericError(
+                "unexpected character".to_string(),
+            )),
+        }
+    }
+
+    /// Read a token after '{'.
+    ///
+    /// Converted from JSONParser::advanceAfterObjectOpen.
+    fn advance_after_object_open(&mut self) -> Result<Token, TokenReaderError> {
+        if !self.skip_whitespace()? {
+            return Err(TokenReaderError::GenericError(
+                "end of data while reading object contents".to_string(),
+            ));
+        }
+
+        match self.current {
+            b'"' => self.read_string(),
+            b'}' => {
+                self.advance_char()?;
+                Ok(Token::ObjectClose)
+            }
+            _ => Err(TokenReaderError::GenericError(
+                "expected property name or '}'".to_string(),
+            )),
+        }
+    }
+
+    /// Read a token after array element.
+    ///
+    /// Converted from JSONParser::advanceAfterArrayElement.
+    fn advance_after_array_element(&mut self) -> Result<Token, TokenReaderError> {
+        if !self.skip_whitespace()? {
+            return Err(TokenReaderError::GenericError(
+                "end of data when ',' or ']' was expected".to_string(),
+            ));
+        }
+
+        match self.current {
+            b',' => {
+                self.advance_char()?;
+                Ok(Token::Comma)
+            }
+            b']' => {
+                self.advance_char()?;
+                Ok(Token::ArrayClose)
+            }
+            _ => Err(TokenReaderError::GenericError(
+                "expected ',' or ']' after array element".to_string(),
+            )),
+        }
+    }
+
+    /// Read a token after property name.
+    ///
+    /// Converted from JSONParser::advancePropertyName.
+    fn advance_property_name(&mut self) -> Result<Token, TokenReaderError> {
+        if !self.skip_whitespace()? {
+            return Err(TokenReaderError::GenericError(
+                "end of data when property name was expected".to_string(),
+            ));
+        }
+
+        match self.current {
+            b'"' => self.read_string(),
+            _ => Err(TokenReaderError::GenericError(
+                "expected double-quoted property name".to_string(),
+            )),
+        }
+    }
+
+    /// Read a token after ':'.
+    ///
+    /// Converted from JSONParser::advancePropertyColon.
+    fn advance_property_colon(&mut self) -> Result<Token, TokenReaderError> {
+        if !self.skip_whitespace()? {
+            return Err(TokenReaderError::GenericError(
+                "end of data after property name when ':' was expected".to_string(),
+            ));
+        }
+
+        match self.current {
+            b':' => {
+                self.advance_char()?;
+                Ok(Token::Colon)
+            }
+            _ => Err(TokenReaderError::GenericError(
+                "expected ':' after property name in object".to_string(),
+            )),
+        }
+    }
+
+    /// Read a token after object property.
+    ///
+    /// Converted from JSONParser::advanceAfterProperty.
+    fn advance_after_property(&mut self) -> Result<Token, TokenReaderError> {
+        if !self.skip_whitespace()? {
+            return Err(TokenReaderError::GenericError(
+                "end of data after property value in object".to_string(),
+            ));
+        }
+
+        match self.current {
+            b',' => {
+                self.advance_char()?;
+                Ok(Token::Comma)
+            }
+            b'}' => {
+                self.advance_char()?;
+                Ok(Token::ObjectClose)
+            }
+            _ => Err(TokenReaderError::GenericError(
+                "expected ',' or '}' after property value in object".to_string(),
+            )),
+        }
+    }
+
+    /// Pops an object from the stack and convert it to a value.
+    ///
+    /// Corresponds to JSONParser::finishObject.
+    fn finish_object(&mut self) -> Rc<Value> {
+        let properties = match self.stack.pop() {
+            Some(State::FinishObjectMember(properties)) => properties,
+            _ => {
+                panic!("there should be an object on the stack");
+            }
+        };
+
+        let mut properties_map = HashMap::new();
+        for prop in properties {
+            properties_map.insert(prop.key, prop.value);
+        }
+        Rc::new(Value::Object(Rc::new(properties_map)))
+    }
+
+    /// Pops an array from the stack and convert it to a value.
+    ///
+    /// Corresponds to JSONParser::finishArray.
+    fn finish_array(&mut self) -> Rc<Value> {
+        let elements = match self.stack.pop() {
+            Some(State::FinishArrayElement(elements)) => elements,
+            _ => {
+                panic!("there should be an array on the stack");
+            }
+        };
+
+        Rc::new(Value::Array(Rc::new(elements)))
+    }
+
+    /// Parse the stream and returns a value.
+    ///
+    /// Converted from JSONParser::parse.
+    pub fn parse(&mut self) -> Result<Rc<Value>, TokenReaderError> {
+        let mut state = NextState {
+            prev_value: Rc::new(Value::Null),
+            state: State::JSONValue,
+        };
+
+        // Populate the current code unit.
+        self.advance_char()?;
+
+        // Loop for stack.
+        let value = loop {
+            // Corresponds to switch-case jump in the original code.
+            let mut next_label = match state {
+                NextState {
+                    prev_value,
+                    state: State::FinishArrayElement(mut elements),
+                } => {
+                    elements.push(prev_value);
+                    self.stack.push(State::FinishArrayElement(elements));
+
+                    goto(NextLabel::FinishArrayElement)
+                }
+                NextState {
+                    prev_value,
+                    state: State::FinishObjectMember(mut properties),
+                } => {
+                    properties
+                        .last_mut()
+                        .expect("there should already be a property with key populated")
+                        .value = prev_value;
+                    self.stack.push(State::FinishObjectMember(properties));
+
+                    goto(NextLabel::FinishObjectMember)
+                }
+                NextState {
+                    state: State::JSONValue,
+                    ..
+                } => goto(NextLabel::JSONValue),
+            };
+
+            // Loop which emulates switch and goto in the original code.
+            let value = loop {
+                next_label = match next_label {
+                    NextLabel::FinishObjectMember => {
+                        let token = self.advance_after_property()?;
+                        match token {
+                            Token::ObjectClose => {
+                                break self.finish_object();
+                            }
+                            Token::Comma => {
+                                let next_token = self.advance_property_name()?;
+                                goto(NextLabel::JSONMember(next_token))
+                            }
+                            _ => {
+                                return Err(TokenReaderError::GenericError(
+                                    "expected ',' or '}' after property-value pair in object literal".to_string()));
+                            }
+                        }
+                    }
+                    NextLabel::JSONMember(token) => match token {
+                        Token::String(s) => {
+                            match self.stack.last_mut() {
+                                Some(State::FinishObjectMember(properties)) => {
+                                    properties.push(Property {
+                                        key: s,
+                                        value: Rc::new(Value::Null),
+                                    });
+                                }
+                                _ => {
+                                    panic!("there should be an object on the stack after reading property key");
+                                }
+                            }
+                            let token = self.advance_property_colon()?;
+                            match token {
+                                Token::Colon => goto(NextLabel::JSONValue),
+                                _ => {
+                                    panic!("shouldn't happen");
+                                }
+                            }
+                        }
+                        _ => {
+                            return Err(TokenReaderError::GenericError(
+                                "property names must be double-quoted strings".to_string(),
+                            ));
+                        }
+                    },
+                    NextLabel::FinishArrayElement => {
+                        let token = self.advance_after_array_element()?;
+                        match token {
+                            Token::Comma => goto(NextLabel::JSONValue),
+                            Token::ArrayClose => {
+                                break self.finish_array();
+                            }
+                            _ => {
+                                panic!("shouldn't happen");
+                            }
+                        }
+                    }
+                    NextLabel::JSONValue => {
+                        let token = self.advance()?;
+                        goto(NextLabel::JSONValueSwitch(token))
+                    }
+                    NextLabel::JSONValueSwitch(token) => match token {
+                        Token::String(s) => {
+                            break Rc::new(Value::String(s));
+                        }
+                        Token::Number(n) => {
+                            break Rc::new(Value::Number(n));
+                        }
+                        Token::True => {
+                            break Rc::new(Value::Bool(true));
+                        }
+                        Token::False => {
+                            break Rc::new(Value::Bool(true));
+                        }
+                        Token::Null => {
+                            break Rc::new(Value::Null);
+                        }
+                        Token::ArrayOpen => {
+                            let elements: Vec<Rc<Value>> = Vec::new();
+                            self.stack.push(State::FinishArrayElement(elements));
+
+                            let token = self.advance()?;
+                            match token {
+                                Token::ArrayClose => {
+                                    break self.finish_array();
+                                }
+                                _ => goto(NextLabel::JSONValueSwitch(token)),
+                            }
+                        }
+                        Token::ObjectOpen => {
+                            let properties: Vec<Property> = Vec::new();
+                            self.stack.push(State::FinishObjectMember(properties));
+
+                            let token = self.advance_after_object_open()?;
+                            match token {
+                                Token::ObjectClose => {
+                                    break self.finish_object();
+                                }
+                                _ => goto(NextLabel::JSONMember(token)),
+                            }
+                        }
+                        Token::ArrayClose | Token::ObjectClose | Token::Colon | Token::Comma => {
+                            return Err(TokenReaderError::GenericError(
+                                "unexpected character".to_string(),
+                            ));
+                        }
+                    },
+                }
+            };
+
+            match self.stack.pop() {
+                None => {
+                    break value;
+                }
+                Some(next) => {
+                    state = NextState {
+                        prev_value: value,
+                        state: next,
+                    };
+                }
+            }
+        };
+
+        loop {
+            if !self.advance_char()? {
+                break;
+            }
+            if !Self::is_json_whitespace(self.current) {
+                return Err(TokenReaderError::GenericError(
+                    "unexpected non-whitespace character after JSON data".to_string(),
+                ));
+            }
+        }
+
+        Ok(value)
+    }
+}

--- a/crates/binjs_io/src/json/read.rs
+++ b/crates/binjs_io/src/json/read.rs
@@ -1,0 +1,476 @@
+//! A JSON reader with extra support for JSON->BinAST converter.
+//! The input JSON file is supposed to be the output of the JSON writer,
+//! filtered with some command to generate an invalid content.
+//! Some methods implemented on Decoder are for binjs_convert_from_json command.
+
+use io::{FileStructurePrinter, Path, TokenReader};
+use TokenReaderError;
+
+use binjs_shared::{FieldName, IdentifierName, InterfaceName, PropertyKey, SharedString};
+
+pub type PathItem = binjs_shared::ast::PathItem<InterfaceName, /* Field */ (usize, FieldName)>;
+
+use super::parser::Parser;
+use super::value::{ObjectValue, Value};
+
+use std::io::Read;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+/// Context for either list or tuple.
+enum Context {
+    List {
+        /// The list's items.
+        items: Rc<Vec<Rc<Value>>>,
+
+        /// The next item's index.
+        index: usize,
+    },
+    Tuple {
+        /// The tuple's tag.
+        interface: InterfaceName,
+
+        /// The tuple's field names.
+        field_names: Rc<Box<[FieldName]>>,
+
+        /// The tuple's field values.
+        fields: Rc<Vec<Rc<Value>>>,
+
+        /// The next field's index.
+        index: usize,
+    },
+}
+impl Context {
+    /// Create a new list context.
+    fn new_list(items: Rc<Vec<Rc<Value>>>) -> Self {
+        Context::List { items, index: 0 }
+    }
+
+    /// Create a new tuple context.
+    fn new_tuple(
+        interface: InterfaceName,
+        field_names: Rc<Box<[FieldName]>>,
+        fields: Rc<Vec<Rc<Value>>>,
+    ) -> Self {
+        Context::Tuple {
+            interface,
+            field_names,
+            fields,
+            index: 0,
+        }
+    }
+
+    /// Convert the context to PathItem.
+    /// If this is a list context, returns None.
+    /// If this is a tuple context, returns Some(PathItem).
+    fn to_path_item(&self) -> Option<PathItem> {
+        match self {
+            Context::List { .. } => None,
+            Context::Tuple {
+                interface,
+                field_names,
+                index,
+                ..
+            } => {
+                if *index == field_names.len() {
+                    return None;
+                }
+
+                Some(PathItem {
+                    interface: interface.clone(),
+                    field: (*index, field_names[*index].clone()),
+                })
+            }
+        }
+    }
+}
+
+/// The next item in the tree, designates which method to call on the decoder.
+///
+/// A list and a tuple have corresponding EndOf* when all items/fields are read.
+pub enum NextType {
+    String,
+    Enum,
+    IdentifierName,
+    PropertyKey,
+    Float,
+    UnsignedLong,
+    Bool,
+    List,
+    EndOfList,
+    TaggedTuple,
+    EndOfTaggedTuple,
+    End,
+    Error,
+}
+
+pub struct Decoder<R: Read> {
+    /// The context stack.
+    contexts: Vec<Context>,
+
+    phantom: PhantomData<R>,
+}
+impl<R: Read> Decoder<R> {
+    pub fn new(source: R) -> Result<Self, TokenReaderError> {
+        let mut parser = Parser::new(source);
+        let root = parser.parse()?;
+        Ok(Decoder {
+            contexts: vec![Context::new_list(Rc::new(vec![root]))],
+            phantom: PhantomData,
+        })
+    }
+
+    /// Enter the given list.
+    fn enter_list(&mut self, items: Rc<Vec<Rc<Value>>>) -> Result<(), TokenReaderError> {
+        self.contexts.push(Context::new_list(items));
+        Ok(())
+    }
+
+    /// Enter the given tuple.
+    fn enter_tuple(
+        &mut self,
+        interface: InterfaceName,
+        field_names: Rc<Box<[FieldName]>>,
+        fields: Rc<Vec<Rc<Value>>>,
+    ) -> Result<(), TokenReaderError> {
+        self.contexts
+            .push(Context::new_tuple(interface, field_names, fields));
+        Ok(())
+    }
+
+    /// Exit the current list.
+    /// Fails if not all items are read.
+    fn exit_list(&mut self) -> Result<(), TokenReaderError> {
+        match self.contexts.pop() {
+            Some(Context::List { items, index }) => {
+                if index == items.len() {
+                    Ok(())
+                } else {
+                    Err(TokenReaderError::GenericError(
+                        "Exiting a list without reading all items".to_string(),
+                    ))
+                }
+            }
+            Some(Context::Tuple { .. }) => Err(TokenReaderError::GenericError(
+                "Unmatching exit, expected list, got tuple".to_string(),
+            )),
+            None => Err(TokenReaderError::GenericError(
+                "No more context to exit".to_string(),
+            )),
+        }
+    }
+
+    /// Exit the current list.
+    /// Fails if not all items are read.
+    fn exit_tuple(&mut self) -> Result<(), TokenReaderError> {
+        match self.contexts.pop() {
+            Some(Context::Tuple { fields, index, .. }) => {
+                if index == fields.len() {
+                    Ok(())
+                } else {
+                    Err(TokenReaderError::GenericError(
+                        "Exiting a tuple without reading all fields".to_string(),
+                    ))
+                }
+            }
+            Some(Context::List { .. }) => Err(TokenReaderError::GenericError(
+                "Unmatching exit, expected tuple, got list".to_string(),
+            )),
+            None => Err(TokenReaderError::GenericError(
+                "No more context to exit".to_string(),
+            )),
+        }
+    }
+
+    /// Convert the "field_names" value from the JSON to the array of FieldName.
+    fn convert_field_names(
+        field_names: Rc<Vec<Rc<Value>>>,
+    ) -> Result<Rc<Box<[FieldName]>>, TokenReaderError> {
+        let mut v = Vec::with_capacity(field_names.len());
+        for item in field_names.iter() {
+            v.push(FieldName(item.as_string()?));
+        }
+        Ok(Rc::new(v.into_boxed_slice()))
+    }
+
+    /// Get the next item from the topmost context.
+    /// Fails if there's no more context, or there's no more items/fields in
+    /// the current list/tuple.
+    fn next_impl(&mut self, consume: bool) -> Result<Rc<Value>, TokenReaderError> {
+        match self.contexts.last_mut() {
+            Some(Context::List {
+                ref mut items,
+                ref mut index,
+            }) => {
+                if *index < (*items).len() {
+                    let val = (*items)[*index].clone();
+                    if consume {
+                        *index += 1;
+                    }
+                    Ok(val)
+                } else {
+                    Err(TokenReaderError::GenericError(
+                        "No more item in the list".to_string(),
+                    ))
+                }
+            }
+            Some(Context::Tuple {
+                ref mut fields,
+                ref mut index,
+                ..
+            }) => {
+                if *index < (*fields).len() {
+                    let val = (*fields)[*index].clone();
+                    if consume {
+                        *index += 1;
+                    }
+                    Ok(val)
+                } else {
+                    Err(TokenReaderError::GenericError(
+                        "No more field in the tuple".to_string(),
+                    ))
+                }
+            }
+            None => Err(TokenReaderError::GenericError("No more item".to_string())),
+        }
+    }
+
+    /// Returns the corresponding NextType for the next value.
+    fn type_of(val: Rc<Value>) -> NextType {
+        let obj = match val.as_object() {
+            Ok(obj) => obj,
+            Err(_) => {
+                return NextType::Error;
+            }
+        };
+        let type_ = match obj.get_string_property("type") {
+            Ok(type_) => type_,
+            Err(_) => {
+                return NextType::Error;
+            }
+        };
+        if type_.as_str() == "string" {
+            return NextType::String;
+        }
+        if type_.as_str() == "enum" {
+            return NextType::Enum;
+        }
+        if type_.as_str() == "identifier name" {
+            return NextType::IdentifierName;
+        }
+        if type_.as_str() == "property key" {
+            return NextType::PropertyKey;
+        }
+        if type_.as_str() == "float" {
+            return NextType::Float;
+        }
+        if type_.as_str() == "unsigned long" {
+            return NextType::UnsignedLong;
+        }
+        if type_.as_str() == "bool" {
+            return NextType::Bool;
+        }
+        if type_.as_str() == "list" {
+            return NextType::List;
+        }
+        if type_.as_str() == "tagged tuple" {
+            return NextType::TaggedTuple;
+        }
+        return NextType::Error;
+    }
+
+    /// Returns which method to call to get the next item.
+    ///
+    /// The consumer is supposed to call this and branch to each
+    /// TokenReader::*_at method call.
+    pub fn next_type(&self) -> NextType {
+        match self.contexts.last() {
+            Some(Context::List { items, index }) => {
+                if *index < items.len() {
+                    Self::type_of(items[*index].clone())
+                } else {
+                    if self.contexts.len() == 1 {
+                        // The top level is also using List.
+                        NextType::End
+                    } else {
+                        NextType::EndOfList
+                    }
+                }
+            }
+            Some(Context::Tuple { fields, index, .. }) => {
+                if *index < fields.len() {
+                    Self::type_of(fields[*index].clone())
+                } else {
+                    NextType::EndOfTaggedTuple
+                }
+            }
+            None => NextType::End,
+        }
+    }
+
+    /// Get the next item, and increment index.
+    fn next(&mut self) -> Result<Rc<Value>, TokenReaderError> {
+        self.next_impl(true)
+    }
+
+    /// Get the next item, but don't increment index.
+    fn next_without_consume(&mut self) -> Result<Rc<Value>, TokenReaderError> {
+        self.next_impl(false)
+    }
+
+    /// Increment the index which is skipped by next_without_consume.
+    fn consume(&mut self) -> Result<(), TokenReaderError> {
+        // Reuse next_impl code just to increment index.
+        self.next_impl(true)?;
+        Ok(())
+    }
+
+    /// Returns then path to the current context.
+    ///
+    /// Supposed to be fed to {TokenReader,TokenWriter}::*_at methods.
+    pub fn get_path(&self) -> Path {
+        let mut items = Vec::new();
+        for context in self.contexts.iter() {
+            match context.to_path_item() {
+                Some(item) => {
+                    items.push(item);
+                }
+                None => {}
+            }
+        }
+
+        if items.len() == 0 {
+            Path::from(Vec::new())
+        } else {
+            Path::from(items)
+        }
+    }
+
+    /// Returns the current tuple context's interface name and field names.
+    ///
+    /// Supposed to be fed to TokenWriter::exit_tagged_tuple_at.
+    ///
+    /// This method should be called before TokenReader::exit_tagged_tuple_at
+    /// for the corresponding tagged tuple.
+    pub fn current_tagged_tuple_info(&self) -> (InterfaceName, Rc<Box<[FieldName]>>) {
+        match self.contexts.last() {
+            Some(Context::Tuple {
+                interface,
+                field_names,
+                ..
+            }) => (interface.clone(), field_names.clone()),
+            _ => {
+                panic!("The current context should be tuple");
+            }
+        }
+    }
+}
+
+impl<R: Read> FileStructurePrinter for Decoder<R> {}
+
+impl<R: Read> TokenReader for Decoder<R> {
+    // ---- String types
+
+    fn string_at(&mut self, _path: &Path) -> Result<Option<SharedString>, TokenReaderError> {
+        let obj = self.next()?.as_object()?;
+        obj.expect_string_property("type", "string")?;
+        Ok(obj.get_string_or_null_property("value")?)
+    }
+
+    fn string_enum_at(&mut self, _path: &Path) -> Result<SharedString, TokenReaderError> {
+        let obj = self.next()?.as_object()?;
+        obj.expect_string_property("type", "enum")?;
+        Ok(obj.get_string_property("value")?)
+    }
+
+    fn identifier_name_at(
+        &mut self,
+        _path: &Path,
+    ) -> Result<Option<IdentifierName>, TokenReaderError> {
+        let obj = self.next()?.as_object()?;
+        obj.expect_string_property("type", "identifier name")?;
+        Ok(obj
+            .get_string_or_null_property("value")?
+            .map(IdentifierName))
+    }
+
+    fn property_key_at(&mut self, _path: &Path) -> Result<Option<PropertyKey>, TokenReaderError> {
+        let obj = self.next()?.as_object()?;
+        obj.expect_string_property("type", "property key")?;
+        Ok(obj.get_string_or_null_property("value")?.map(PropertyKey))
+    }
+
+    // ---- Primitive types
+
+    fn float_at(&mut self, _path: &Path) -> Result<Option<f64>, TokenReaderError> {
+        let obj = self.next()?.as_object()?;
+        obj.expect_string_property("type", "float")?;
+        Ok(obj.get_number_or_null_property("value")?)
+    }
+
+    fn unsigned_long_at(&mut self, _path: &Path) -> Result<u32, TokenReaderError> {
+        let obj = self.next()?.as_object()?;
+        obj.expect_string_property("type", "unsigned long")?;
+        Ok(obj.get_number_property("value")? as u32)
+    }
+
+    fn bool_at(&mut self, _path: &Path) -> Result<Option<bool>, TokenReaderError> {
+        let obj = self.next()?.as_object()?;
+        obj.expect_string_property("type", "bool")?;
+        Ok(obj.get_bool_or_null_property("value")?)
+    }
+
+    // ---- Lazy
+
+    fn offset_at(&mut self, __path: &Path) -> Result<u32, TokenReaderError> {
+        unimplemented!()
+    }
+
+    // ---- Composed types
+
+    fn enter_list_at(&mut self, _path: &Path) -> Result<u32, TokenReaderError> {
+        let obj = self.next_without_consume()?.as_object()?;
+        obj.expect_string_property("type", "list")?;
+        let value = obj.get_array_property("value")?;
+        let len = value.len() as u32;
+
+        self.enter_list(value)?;
+
+        Ok(len)
+    }
+    fn exit_list_at(&mut self, _path: &Path) -> Result<(), TokenReaderError> {
+        self.exit_list()?;
+        self.consume()?;
+        Ok(())
+    }
+
+    fn enter_tagged_tuple_at(
+        &mut self,
+        _path: &Path,
+    ) -> Result<(InterfaceName, Option<std::rc::Rc<Box<[FieldName]>>>), TokenReaderError> {
+        let obj = self.next_without_consume()?.as_object()?;
+        obj.expect_string_property("type", "tagged tuple")?;
+        let name = InterfaceName(obj.get_string_property("interface")?);
+        let field_names = Self::convert_field_names(obj.get_array_property("field_names")?)?;
+        let fields = obj.get_array_property("fields")?;
+
+        if field_names.len() != fields.len() {
+            return Err(TokenReaderError::GenericError(
+                "field_names and fields should have the same length".to_string(),
+            ));
+        }
+
+        self.enter_tuple(name.clone(), field_names.clone(), fields)?;
+
+        Ok((name, Some(field_names)))
+    }
+    fn exit_tagged_tuple_at(&mut self, _path: &Path) -> Result<(), TokenReaderError> {
+        self.exit_tuple()?;
+        self.consume()?;
+        Ok(())
+    }
+
+    fn enter_untagged_tuple_at(&mut self, __path: &Path) -> Result<(), TokenReaderError> {
+        unimplemented!()
+    }
+}

--- a/crates/binjs_io/src/json/value.rs
+++ b/crates/binjs_io/src/json/value.rs
@@ -1,0 +1,216 @@
+/// JS value in JSON.
+use TokenReaderError;
+
+use binjs_shared::SharedString;
+
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// JS value in JSON.
+pub enum Value {
+    String(SharedString),
+    Number(f64),
+    Object(Rc<HashMap<SharedString, Rc<Value>>>),
+    Array(Rc<Vec<Rc<Value>>>),
+    Bool(bool),
+    Null,
+}
+impl Value {
+    /// Get the string content from the value.
+    /// Fails if the value is not string.
+    pub fn as_string(&self) -> Result<SharedString, TokenReaderError> {
+        match self {
+            Value::String(s) => Ok(s.clone()),
+            _ => Err(TokenReaderError::GenericError(
+                "Expected a string".to_string(),
+            )),
+        }
+    }
+
+    /// Get the object content from the value.
+    /// Fails if the value is not object.
+    pub fn as_object(&self) -> Result<Rc<HashMap<SharedString, Rc<Value>>>, TokenReaderError> {
+        match self {
+            Value::Object(obj) => Ok(obj.clone()),
+            _ => Err(TokenReaderError::GenericError(
+                "Expected an object".to_string(),
+            )),
+        }
+    }
+}
+
+/// Methods to treat HashMap as JS Object.
+pub trait ObjectValue {
+    /// Get the property from the object.
+    /// Fails if the property doesn't exist.
+    fn get_property(&self, key: &'static str) -> Result<Rc<Value>, TokenReaderError>;
+
+    /// Get the property from the object and return bool or null content.
+    /// Returns Some(bool) if the property is bool.
+    /// Returns None if the property is null
+    ///
+    /// Fails if the property doesn't exist, or the property value is neither
+    /// bool nor null.
+    fn get_bool_or_null_property(
+        &self,
+        key: &'static str,
+    ) -> Result<Option<bool>, TokenReaderError>;
+
+    /// Get the property from the object and return number content.
+    /// Fails if the property doesn't exist, or the property value is not number.
+    fn get_number_property(&self, key: &'static str) -> Result<f64, TokenReaderError>;
+
+    /// Get the property from the object and return number or null content.
+    /// Returns Some(f64) if the property is number.
+    /// Returns None if the property is null
+    ///
+    /// Fails if the property doesn't exist, or the property value is neither
+    /// number nor null.
+    fn get_number_or_null_property(
+        &self,
+        key: &'static str,
+    ) -> Result<Option<f64>, TokenReaderError>;
+
+    /// Get the property from the object and return string content.
+    /// Fails if the property doesn't exist, or the property value is not string.
+    fn get_string_property(&self, key: &'static str) -> Result<SharedString, TokenReaderError>;
+
+    /// Get the property from the object and return string or null content.
+    /// Returns Some(SharedString) if the property is string.
+    /// Returns None if the property is null
+    ///
+    /// Fails if the property doesn't exist, or the property value is neither
+    /// string nor null.
+    fn get_string_or_null_property(
+        &self,
+        key: &'static str,
+    ) -> Result<Option<SharedString>, TokenReaderError>;
+
+    /// Get the property from the object and check if the value is a string
+    /// with the expected content.
+    ///
+    /// Fails if the property doesn't exist, or the property value is not string,
+    /// or the string doesn't match.
+    fn expect_string_property(
+        &self,
+        key: &'static str,
+        value: &'static str,
+    ) -> Result<(), TokenReaderError>;
+
+    /// Get the property from the object and return array content.
+    /// Fails if the property doesn't exist, or the property value is not array.
+    fn get_array_property(&self, key: &'static str)
+        -> Result<Rc<Vec<Rc<Value>>>, TokenReaderError>;
+}
+
+impl ObjectValue for HashMap<SharedString, Rc<Value>> {
+    fn get_property(&self, key: &'static str) -> Result<Rc<Value>, TokenReaderError> {
+        match self.get(&SharedString::from_str(key)) {
+            Some(val) => Ok(val.clone()),
+            None => Err(TokenReaderError::GenericError(format!(
+                "Missing \"{}\" property",
+                key
+            ))),
+        }
+    }
+
+    fn get_bool_or_null_property(
+        &self,
+        key: &'static str,
+    ) -> Result<Option<bool>, TokenReaderError> {
+        let prop = self.get_property(key)?;
+        match prop.borrow() {
+            Value::Bool(b) => Ok(Some(*b)),
+            Value::Null => Ok(None),
+            _ => Err(TokenReaderError::GenericError(format!(
+                "Property \"{}\" should be a bool or a null",
+                key
+            ))),
+        }
+    }
+
+    fn get_number_property(&self, key: &'static str) -> Result<f64, TokenReaderError> {
+        let prop = self.get_property(key)?;
+        match prop.borrow() {
+            Value::Number(n) => Ok(*n),
+            _ => Err(TokenReaderError::GenericError(format!(
+                "Property \"{}\" should be a number",
+                key
+            ))),
+        }
+    }
+
+    fn get_number_or_null_property(
+        &self,
+        key: &'static str,
+    ) -> Result<Option<f64>, TokenReaderError> {
+        let prop = self.get_property(key)?;
+        match prop.borrow() {
+            Value::Number(n) => Ok(Some(*n)),
+            Value::Null => Ok(None),
+            _ => Err(TokenReaderError::GenericError(format!(
+                "Property \"{}\" should be a number or a null",
+                key
+            ))),
+        }
+    }
+
+    fn get_string_property(&self, key: &'static str) -> Result<SharedString, TokenReaderError> {
+        let prop = self.get_property(key)?;
+        match prop.borrow() {
+            Value::String(s) => Ok(s.clone()),
+            _ => Err(TokenReaderError::GenericError(format!(
+                "Property \"{}\" should be a string",
+                key
+            ))),
+        }
+    }
+
+    fn get_string_or_null_property(
+        &self,
+        key: &'static str,
+    ) -> Result<Option<SharedString>, TokenReaderError> {
+        let prop = self.get_property(key)?;
+        match prop.borrow() {
+            Value::String(s) => Ok(Some(s.clone())),
+            Value::Null => Ok(None),
+            _ => Err(TokenReaderError::GenericError(format!(
+                "Property \"{}\" should be a string or a null",
+                key
+            ))),
+        }
+    }
+
+    fn expect_string_property(
+        &self,
+        key: &'static str,
+        value: &'static str,
+    ) -> Result<(), TokenReaderError> {
+        let s = self.get_string_property(key)?;
+        if s.as_str() == value {
+            Ok(())
+        } else {
+            Err(TokenReaderError::GenericError(format!(
+                "Property \"{}\" should be \"{}\", got \"{}\"",
+                key,
+                value,
+                s.as_str()
+            )))
+        }
+    }
+
+    fn get_array_property(
+        &self,
+        key: &'static str,
+    ) -> Result<Rc<Vec<Rc<Value>>>, TokenReaderError> {
+        let prop = self.get_property(key)?;
+        match prop.borrow() {
+            Value::Array(a) => Ok(a.clone()),
+            _ => Err(TokenReaderError::GenericError(format!(
+                "Property \"{}\" should be an array",
+                key
+            ))),
+        }
+    }
+}

--- a/crates/binjs_io/src/json/write.rs
+++ b/crates/binjs_io/src/json/write.rs
@@ -1,0 +1,352 @@
+//! A JSON writer for BinAST file structure.
+//! The written file is supposed to be filtered with some command to generate
+//! an invalid content and then fed to binjs_convert_from_json command to
+//! generate BinAST file with the invalid content.
+
+use io::{Path, TokenWriter};
+use TokenWriterError;
+
+use binjs_shared::{FieldName, IdentifierName, InterfaceName, Node, PropertyKey, SharedString};
+
+use escaped_wtf8;
+
+/// Context for either list or tuple.
+enum Context {
+    List {
+        /// The list of stringified items.
+        items: Vec<String>,
+    },
+    Tuple {
+        /// The interface name.
+        interface: InterfaceName,
+
+        /// The list of stringified fields.
+        fields: Vec<String>,
+    },
+}
+
+pub struct TreeTokenWriter {
+    /// The context stack.
+    contexts: Vec<Context>,
+}
+
+impl TreeTokenWriter {
+    pub fn new() -> Self {
+        Self {
+            contexts: vec![Context::List { items: Vec::new() }],
+        }
+    }
+
+    /// Add the given stringified item/field to the current list/tuple.
+    fn push(&mut self, v: String) {
+        match self.contexts.last_mut() {
+            Some(Context::Tuple { fields, .. }) => {
+                fields.push(v);
+            }
+            Some(Context::List { items }) => {
+                items.push(v);
+            }
+            _ => {
+                panic!("context mismatch");
+            }
+        }
+    }
+
+    /// Append whitespaces for indent to the given string
+    fn indent(&self, target: &mut String) {
+        target.push_str(str::repeat("    ", self.contexts.len() - 1).as_str());
+    }
+}
+
+impl TokenWriter for TreeTokenWriter {
+    type Data = Vec<u8>;
+
+    fn done(mut self) -> Result<Self::Data, TokenWriterError> {
+        match self.contexts.pop() {
+            Some(Context::List { mut items }) => Ok(items
+                .pop()
+                .expect("There should be only one item at the top level")
+                .as_bytes()
+                .to_vec()),
+            _ => {
+                panic!("context mismatch");
+            }
+        }
+    }
+
+    fn enter_tagged_tuple_at(
+        &mut self,
+        _node: &Node,
+        tag: &InterfaceName,
+        _children: &[&FieldName],
+        _path: &Path,
+    ) -> Result<(), TokenWriterError> {
+        self.contexts.push(Context::Tuple {
+            interface: tag.clone(),
+            fields: Vec::new(),
+        });
+        Ok(())
+    }
+    fn exit_tagged_tuple_at(
+        &mut self,
+        _node: &Node,
+        _tag: &InterfaceName,
+        children: &[&FieldName],
+        _path: &Path,
+    ) -> Result<(), TokenWriterError> {
+        match self.contexts.pop() {
+            Some(Context::Tuple {
+                interface: tag,
+                fields,
+            }) => {
+                // Format
+                //   {
+                //     "type": "tagged tuple",
+                //     "interface": "<interface name>",
+                //     "field_names": [
+                //       "<field_name>",
+                //       ...
+                //     ],
+                //     "fields": [
+                //       <field>,
+                //       ...
+                //     ],
+                //   }
+
+                let mut s = String::new();
+                self.indent(&mut s);
+                s.push_str("{\n");
+
+                self.indent(&mut s);
+                s.push_str("  \"type\": \"tagged tuple\",\n");
+                self.indent(&mut s);
+
+                s.push_str("  \"interface\": \"");
+                s.push_str(tag.as_str());
+                s.push_str("\",\n");
+
+                self.indent(&mut s);
+                s.push_str("  \"field_names\": [\n");
+                {
+                    let mut first = true;
+                    for field_name in children {
+                        if !first {
+                            s.push_str(",\n");
+                        }
+                        self.indent(&mut s);
+                        s.push_str("    ");
+                        s.push_str(escaped_wtf8::to_json(field_name.as_shared_string()).as_str());
+                        first = false;
+                    }
+                    if !first {
+                        s.push_str("\n");
+                    }
+                }
+                self.indent(&mut s);
+                s.push_str("  ],\n");
+
+                self.indent(&mut s);
+                s.push_str("  \"fields\": [\n");
+                {
+                    let mut first = true;
+                    for field in fields {
+                        if !first {
+                            s.push_str(",\n");
+                        }
+                        s.push_str(field.as_str());
+                        first = false;
+                    }
+                    if !first {
+                        s.push_str("\n");
+                    }
+                }
+                self.indent(&mut s);
+                s.push_str("  ]\n");
+
+                self.indent(&mut s);
+                s.push_str("}");
+                self.push(s);
+            }
+            _ => {
+                panic!("context mismatch");
+            }
+        };
+        Ok(())
+    }
+
+    fn enter_list_at(&mut self, _len: usize, _path: &Path) -> Result<(), TokenWriterError> {
+        self.contexts.push(Context::List { items: Vec::new() });
+        Ok(())
+    }
+    fn exit_list_at(&mut self, _path: &Path) -> Result<(), TokenWriterError> {
+        match self.contexts.pop() {
+            Some(Context::List { items }) => {
+                // Format
+                //   {
+                //     "type": "list",
+                //     "interface": "<interface name>",
+                //     "value": [
+                //       <item>,
+                //       ...
+                //     ],
+                //   }
+
+                let mut s = String::new();
+                self.indent(&mut s);
+                s.push_str("{\n");
+
+                self.indent(&mut s);
+                s.push_str("  \"type\": \"list\",\n");
+
+                self.indent(&mut s);
+                s.push_str("  \"value\": [\n");
+                let mut first = true;
+                for item in items {
+                    if !first {
+                        s.push_str(",\n");
+                    }
+                    s.push_str(item.as_str());
+                    first = false;
+                }
+                if !first {
+                    s.push_str("\n");
+                }
+                self.indent(&mut s);
+                s.push_str("  ]\n");
+
+                self.indent(&mut s);
+                s.push_str("}");
+                self.push(s);
+            }
+            _ => {
+                panic!("context mismatch");
+            }
+        };
+        Ok(())
+    }
+
+    fn string_at(
+        &mut self,
+        value: Option<&SharedString>,
+        _path: &Path,
+    ) -> Result<(), TokenWriterError> {
+        let mut s = String::new();
+        self.indent(&mut s);
+        s.push_str("{ \"type\": \"string\", \"value\": ");
+        match value {
+            Some(v) => {
+                s.push_str(escaped_wtf8::to_json(v).as_str());
+            }
+            None => {
+                s.push_str("null");
+            }
+        };
+        s.push_str(" }");
+        self.push(s);
+        Ok(())
+    }
+
+    fn string_enum_at(
+        &mut self,
+        value: &SharedString,
+        _path: &Path,
+    ) -> Result<(), TokenWriterError> {
+        let mut s = String::new();
+        self.indent(&mut s);
+        s.push_str("{ \"type\": \"enum\", \"value\": ");
+        s.push_str(escaped_wtf8::to_json(value).as_str());
+        s.push_str(" }");
+        self.push(s);
+        Ok(())
+    }
+
+    fn float_at(&mut self, value: Option<f64>, _path: &Path) -> Result<(), TokenWriterError> {
+        let mut s = String::new();
+        self.indent(&mut s);
+        s.push_str("{ \"type\": \"float\", \"value\": ");
+        match value {
+            Some(v) => {
+                s.push_str(format!("{}", v).as_str());
+            }
+            None => {
+                s.push_str("null");
+            }
+        };
+        s.push_str(" }");
+        self.push(s);
+        Ok(())
+    }
+
+    fn unsigned_long_at(&mut self, value: u32, _path: &Path) -> Result<(), TokenWriterError> {
+        let mut s = String::new();
+        self.indent(&mut s);
+        s.push_str("{ \"type\": \"unsigned long\", \"value\": ");
+        s.push_str(format!("{}", value).as_str());
+        s.push_str(" }");
+        self.push(s);
+        Ok(())
+    }
+
+    fn bool_at(&mut self, value: Option<bool>, _path: &Path) -> Result<(), TokenWriterError> {
+        let mut s = String::new();
+        self.indent(&mut s);
+        s.push_str("{ \"type\": \"bool\", \"value\": ");
+        match value {
+            Some(v) => {
+                s.push_str(format!("{}", v).as_str());
+            }
+            None => {
+                s.push_str("null");
+            }
+        };
+        s.push_str(" }");
+        self.push(s);
+        Ok(())
+    }
+
+    fn offset_at(&mut self, _path: &Path) -> Result<(), TokenWriterError> {
+        unimplemented!()
+    }
+
+    fn property_key_at(
+        &mut self,
+        value: Option<&PropertyKey>,
+        _path: &Path,
+    ) -> Result<(), TokenWriterError> {
+        let mut s = String::new();
+        self.indent(&mut s);
+        s.push_str("{ \"type\": \"property key\", \"value\": ");
+        match value {
+            Some(v) => {
+                s.push_str(escaped_wtf8::to_json(v.as_shared_string()).as_str());
+            }
+            None => {
+                s.push_str("null");
+            }
+        };
+        s.push_str(" }");
+        self.push(s);
+        Ok(())
+    }
+
+    fn identifier_name_at(
+        &mut self,
+        value: Option<&IdentifierName>,
+        _path: &Path,
+    ) -> Result<(), TokenWriterError> {
+        let mut s = String::new();
+        self.indent(&mut s);
+        s.push_str("{ \"type\": \"identifier name\", \"value\": ");
+        match value {
+            Some(v) => {
+                s.push_str(escaped_wtf8::to_json(v.as_shared_string()).as_str());
+            }
+            None => {
+                s.push_str("null");
+            }
+        };
+        s.push_str(" }");
+        self.push(s);
+        Ok(())
+    }
+}

--- a/src/bin/convert_from_json.rs
+++ b/src/bin/convert_from_json.rs
@@ -1,0 +1,211 @@
+//! Convert the JSON file which contains possibly invalid structure into BinAST
+//! file.
+
+extern crate binjs;
+extern crate clap;
+extern crate env_logger;
+extern crate log;
+
+use binjs::io::{TokenReader, TokenWriter};
+
+use binjs::generic::Node;
+
+use std::io::*;
+use std::thread;
+
+use clap::*;
+
+/// A dummy struct for enter_tagged_tuple_at/exit_tagged_tuple_at call.
+struct DummyNode {}
+impl DummyNode {
+    fn new() -> Self {
+        Self {}
+    }
+}
+impl Node for DummyNode {
+    fn name(&self) -> &'static str {
+        "dummy"
+    }
+}
+
+/// READ all items from reader, and write them to writer.
+fn convert<R: Read, W: TokenWriter>(
+    reader: &mut binjs::io::json::read::Decoder<R>,
+    writer: &mut W,
+) {
+    loop {
+        match reader.next_type() {
+            binjs::io::json::read::NextType::String => {
+                let path = reader.get_path();
+                let val = reader.string_at(&path).expect("Error");
+                match val {
+                    Some(s) => {
+                        writer.string_at(Some(&s), &path).expect("Error");
+                    }
+                    None => {
+                        writer.string_at(None, &path).expect("Error");
+                    }
+                }
+            }
+            binjs::io::json::read::NextType::Enum => {
+                let path = reader.get_path();
+                let val = reader.string_enum_at(&path).expect("Error");
+                writer.string_enum_at(&val, &path).expect("Error");
+            }
+            binjs::io::json::read::NextType::IdentifierName => {
+                let path = reader.get_path();
+                let val = reader.identifier_name_at(&path).expect("Error");
+                match val {
+                    Some(s) => {
+                        writer.identifier_name_at(Some(&s), &path).expect("Error");
+                    }
+                    None => {
+                        writer.identifier_name_at(None, &path).expect("Error");
+                    }
+                }
+            }
+            binjs::io::json::read::NextType::PropertyKey => {
+                let path = reader.get_path();
+                let val = reader.property_key_at(&path).expect("Error");
+                match val {
+                    Some(s) => {
+                        writer.property_key_at(Some(&s), &path).expect("Error");
+                    }
+                    None => {
+                        writer.property_key_at(None, &path).expect("Error");
+                    }
+                }
+            }
+            binjs::io::json::read::NextType::Float => {
+                let path = reader.get_path();
+                let val = reader.float_at(&path).expect("Error");
+                writer.float_at(val, &path).expect("Error");
+            }
+            binjs::io::json::read::NextType::UnsignedLong => {
+                let path = reader.get_path();
+                let val = reader.unsigned_long_at(&path).expect("Error");
+                writer.unsigned_long_at(val, &path).expect("Error");
+            }
+            binjs::io::json::read::NextType::Bool => {
+                let path = reader.get_path();
+                let val = reader.bool_at(&path).expect("Error");
+                writer.bool_at(val, &path).expect("Error");
+            }
+            binjs::io::json::read::NextType::List => {
+                let path = reader.get_path();
+                let len = reader.enter_list_at(&path).expect("Error");
+                writer.enter_list_at(len as usize, &path).expect("Error");
+            }
+            binjs::io::json::read::NextType::EndOfList => {
+                let path = reader.get_path();
+                reader.exit_list_at(&path).expect("Error");
+                writer.exit_list_at(&path).expect("Error");
+            }
+            binjs::io::json::read::NextType::TaggedTuple => {
+                let path = reader.get_path();
+                let (name, maybe_field_names) = reader.enter_tagged_tuple_at(&path).expect("Error");
+                let field_names = maybe_field_names.expect("Field names should be populated");
+
+                let mut children = Vec::new();
+                for name in field_names.iter() {
+                    children.push(name);
+                }
+
+                let node = DummyNode::new();
+                writer
+                    .enter_tagged_tuple_at(&node, &name, children.as_slice(), &path)
+                    .expect("Error");
+            }
+            binjs::io::json::read::NextType::EndOfTaggedTuple => {
+                let (name, field_names) = reader.current_tagged_tuple_info();
+
+                let path = reader.get_path();
+                reader.exit_tagged_tuple_at(&path).expect("Error");
+
+                let mut children = Vec::new();
+                for name in field_names.iter() {
+                    children.push(name);
+                }
+
+                let node = DummyNode::new();
+                writer
+                    .exit_tagged_tuple_at(&node, &name, children.as_slice(), &path)
+                    .expect("Error");
+            }
+            binjs::io::json::read::NextType::End => {
+                break;
+            }
+            binjs::io::json::read::NextType::Error => {
+                break;
+            }
+        }
+    }
+}
+
+fn main() {
+    thread::Builder::new()
+        .name("large stack dedicated thread".to_string())
+        .stack_size(20 * 1024 * 1024)
+        .spawn(|| {
+            main_aux();
+        })
+        .expect("Could not launch dedicated thread")
+        .join()
+        .expect("Error in dedicated thread");
+}
+
+fn main_aux() {
+    env_logger::init();
+
+    let matches = App::new("Converter from BinAST JSON format to other BinAST format")
+        .author("arai <arai@mozilla.com>")
+        .about("Convert a BinAST JSON file to other BinAST format file. The JSON file is exported by binjs_encode with advanced json option")
+        .args(&[
+            Arg::with_name("quiet")
+                .long("quiet")
+                .short("q")
+                .help("Do not print progress"),
+        ])
+        .subcommand(binjs::io::Format::subcommand())
+        .get_matches();
+
+    // Format options.
+    let mut format =
+        binjs::io::Format::from_matches(&matches).expect("Could not parse encoding format");
+
+    let mut reader = binjs::io::json::read::Decoder::new(stdin()).expect("Failed to parse");
+
+    match format {
+        binjs_io::Format::Simple { .. } => {
+            let w = binjs::io::simple::TreeTokenWriter::new();
+            let mut writer = binjs::io::TokenWriterTreeAdapter::new(w);
+            convert(&mut reader, &mut writer);
+            let data = writer.done().expect("Error");
+            stdout()
+                .write((*data).as_ref())
+                .expect("Could not write to stdout");
+        }
+        binjs::io::Format::Multipart {
+            ref mut targets, ..
+        } => {
+            let w = binjs::io::multipart::TreeTokenWriter::new(targets.clone());
+            let mut writer = binjs::io::TokenWriterTreeAdapter::new(w);
+            convert(&mut reader, &mut writer);
+            let data = writer.done().expect("Error");
+            stdout()
+                .write((*data).as_ref())
+                .expect("Could not write to stdout");
+        }
+        binjs_io::Format::Entropy { ref options } => {
+            let mut writer = binjs_io::entropy::write::Encoder::new((*options).clone());
+            convert(&mut reader, &mut writer);
+            let data = writer.done().expect("Error");
+            stdout()
+                .write((*data).as_ref())
+                .expect("Could not write to stdout");
+        }
+        _ => {
+            panic!("unsupported format");
+        }
+    }
+}


### PR DESCRIPTION
This add the following:
  - `advanced json` option, which can read/write JSON format of BinAST file
  - `binjs_convert_from_json` command which reads the above JSON file and encode in the other format BinAST file.

`binjs::io::json` contains Decoder, Encoder, JS value, and JSON parser.

I created yet another JSON parser in order to handle escape sequence and lone surrogate,
the code is mostly manual translation of JSONParser in m-c.


The expected usage is the following,
where `some_filter` is a command (maybe written in JS or Python) that mutates the JSON file in order to create invalid content,
like, modifying the tagged tuple field type, or the number of field items, etc.
The final result is the another format of BinAST file with invalid content, which is intended to be used to test decoder (SpiderMonkey impl etc).

```
$ cat test.js \
    | cargo +nightly --run binjs_encode  -- advanced json \
    | some_filter \
    | cargo +nightly --run binjs_convert_from_json > test.binjs
```

This way, such invalid file testcase can be generated only with input `test.js` and `some_filter`,
both are text files, and this is robust to the file format change.
