### PR TITLE
Fix warnings

### DIFF
--- a/crates/binjs_generate_library/src/lib.rs
+++ b/crates/binjs_generate_library/src/lib.rs
@@ -40,7 +40,7 @@ impl RustExporter {
     /// Generate the dynamic version of a `Type`.
     fn type_(type_: &Type, prefix: &str) -> String {
         let spec = Self::type_spec(type_.spec(), prefix);
-        let ref spec = spec.trim_left();
+        let ref spec = spec.trim_start();
         format!("{prefix}{type_}{close}",
             type_ = spec,
             prefix = prefix,
@@ -1068,7 +1068,7 @@ impl<R> Deserialization<R, Option<{rust_name}>> for Deserializer<R> where R: Tok
                     null = null_name,
                     rust_name = rust_name,
                     lowercase_name = name.to_rust_identifier_case()
-                        .trim_right_matches('_'),
+                        .trim_end_matches('_'),
                     fields_def = interface.contents()
                         .fields()
                         .iter()

--- a/crates/binjs_io/src/simple.rs
+++ b/crates/binjs_io/src/simple.rs
@@ -645,7 +645,7 @@ fn test_simple_io() {
                 .write_all(data).unwrap();
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
-        let (len) = reader.enter_list_at(&path)
+        let len = reader.enter_list_at(&path)
             .expect("Reading empty list");
         assert_eq!(len, 0);
 

--- a/crates/binjs_meta/src/util.rs
+++ b/crates/binjs_meta/src/util.rs
@@ -303,7 +303,7 @@ impl<T> Reindentable for T where T: ToStr {
                                 gobbled += pos + 1;
                                 let line = format!("{prefix}{rest}",
                                     prefix = prefix,
-                                    rest = rest[0..pos].trim_right());
+                                    rest = rest[0..pos].trim_end());
                                 lines.push(line)
                             }
                             _else => {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -80,11 +80,11 @@ fn main() {
             .collect::<Vec<_>>();
         for grammar_table in &compressions {
             for strings_table in &compressions {
-                for _ in &compressions {
+                for tree in &compressions {
                     vec.push(Targets {
                         grammar_table: CompressionTarget::new(grammar_table.clone()),
-                        strings_table: CompressionTarget::new(grammar_table.clone()),
-                        tree: CompressionTarget::new(grammar_table.clone()),
+                        strings_table: CompressionTarget::new(strings_table.clone()),
+                        tree: CompressionTarget::new(tree.clone()),
                     });
                 }
             }


### PR DESCRIPTION
Fix warnings reported by Rust and also set default toolchain to nightly for rustup (since code is using nightly-specific `#![feature(...)]`).