### PR TITLE
Update Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Travis status](https://travis-ci.org/binjs/binjs-ref.svg?branch=master)
+[![Travis Status](https://travis-ci.org/binast/binjs-ref.svg?branch=master)](https://travis-ci.org/binast/binjs-ref)
 
 # About the JavaScript Binary AST
 


### PR DESCRIPTION
This was pointing to incorrect (old?) URL and hence was always showing "build status: unknown".