### PR TITLE
Performance: reuse Node.js instance for Shift tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ lzw = "^0.10"
 rand = "^0.6"
 test-logger = "^0.1"
 vec_map = "^0.8"
+which = "^2.0"
 yaml-rust = "^0.4"
 
 [[bin]]

--- a/benches/bench_fb.rs
+++ b/benches/bench_fb.rs
@@ -12,41 +12,18 @@ use binjs::source::*;
 
 use itertools::Itertools;
 
-use std::thread;
-
-const PATHS: [&'static str; 1] = ["tests/data/facebook/single/**/*.js"];
+const PATHS: [&'static str; 1] = ["benches/test.js"];
 const NUMBER_OF_SAMPLES: usize = 3;
 
 fn bench_parsing_one_parser_per_run(bencher: &mut bencher::Bencher) {
-    let bencher = bencher.clone();
-    thread::Builder::new()
-        .name("Large stack dedicated thread".to_string())
-        .stack_size(20 * 1024 * 1024)
-        .spawn(move || {
-            println!("Benchmark: one parser per run");
-            bench_parsing_aux(None, bencher);
-        })
-        .expect("Could not launch dedicated thread")
-        .join()
-        .expect("Error in dedicated thread");
+    bench_parsing_aux(None, bencher);
 }
 
 fn bench_parsing_reuse_parser(bencher: &mut bencher::Bencher) {
-    let bencher = bencher.clone();
-    thread::Builder::new()
-        .name("Large stack dedicated thread".to_string())
-        .stack_size(20 * 1024 * 1024)
-        .spawn(move || {
-            println!("Benchmark: reuse parser");
-            let mut parser = Shift::new();
-            bench_parsing_aux(Some(&mut parser), bencher);
-        })
-        .expect("Could not launch dedicated thread")
-        .join()
-        .expect("Error in dedicated thread");
+    bench_parsing_aux(Some(&mut Shift::new()), bencher);
 }
 
-fn bench_parsing_aux(parser: Option<&mut Shift>, mut bencher: bencher::Bencher) {
+fn bench_parsing_aux(parser: Option<&mut Shift>, bencher: &mut bencher::Bencher) {
     let entries = PATHS
         .iter()
         .map(|path_suffix| format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path_suffix))
@@ -55,20 +32,15 @@ fn bench_parsing_aux(parser: Option<&mut Shift>, mut bencher: bencher::Bencher) 
         .sorted();
     let paths: Vec<_> = entries.into_iter().take(NUMBER_OF_SAMPLES).collect();
     for path in &paths {
-        print!("\n{:?}.", path);
         bencher.iter(|| {
-            print!(".");
             let json = match parser {
                 None => Shift::new()
-                    .parse_file(path.clone())
+                    .parse_file(path)
                     .expect("Could not parse source"),
-                Some(ref parser) => parser
-                    .parse_file(path.clone())
-                    .expect("Could not parse source"),
+                Some(ref parser) => parser.parse_file(path).expect("Could not parse source"),
             };
 
-            let _ =
-                binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST");
+            binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST")
         });
     }
 }

--- a/benches/bench_fb.rs
+++ b/benches/bench_fb.rs
@@ -15,15 +15,19 @@ use itertools::Itertools;
 const PATHS: [&'static str; 1] = ["benches/test.js"];
 const NUMBER_OF_SAMPLES: usize = 3;
 
+fn launch_shift() -> Shift {
+    Shift::try_new().expect("Could not launch Shift")
+}
+
 fn bench_parsing_one_parser_per_run(bencher: &mut bencher::Bencher) {
     bench_parsing_aux(None, bencher);
 }
 
 fn bench_parsing_reuse_parser(bencher: &mut bencher::Bencher) {
-    bench_parsing_aux(Some(&mut Shift::new()), bencher);
+    bench_parsing_aux(Some(&launch_shift()), bencher);
 }
 
-fn bench_parsing_aux(parser: Option<&mut Shift>, bencher: &mut bencher::Bencher) {
+fn bench_parsing_aux(parser: Option<&Shift>, bencher: &mut bencher::Bencher) {
     let entries = PATHS
         .iter()
         .map(|path_suffix| format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path_suffix))
@@ -32,13 +36,18 @@ fn bench_parsing_aux(parser: Option<&mut Shift>, bencher: &mut bencher::Bencher)
         .sorted();
     let paths: Vec<_> = entries.into_iter().take(NUMBER_OF_SAMPLES).collect();
     for path in &paths {
-        bencher.iter(|| {
+        bencher.iter(move || {
+            let shift;
+
             let json = match parser {
-                None => Shift::new()
-                    .parse_file(path)
-                    .expect("Could not parse source"),
-                Some(ref parser) => parser.parse_file(path).expect("Could not parse source"),
-            };
+                Some(parser) => parser,
+                None => {
+                    shift = launch_shift();
+                    &shift
+                }
+            }
+            .parse_file(path)
+            .expect("Could not parse source");
 
             binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST")
         });

--- a/benches/test.js
+++ b/benches/test.js
@@ -1,0 +1,3 @@
+'use strict';
+
+var answer = 42;

--- a/examples/compare_compression.rs
+++ b/examples/compare_compression.rs
@@ -111,7 +111,7 @@ fn main() {
     let mut format =
         binjs::io::Format::from_matches(&matches).expect("Could not determine encoding format");
 
-    let parser = Shift::new();
+    let parser = Shift::try_new().expect("Could not launch Shift");
 
     let mut all_stats = HashMap::new();
 

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -88,7 +88,7 @@ Note that this tool does not attempt to make sure that the files are entirely co
 
     let random_metadata = matches.is_present("random-metadata");
 
-    let parser = Shift::new();
+    let parser = Shift::try_new().expect("Could not launch Shift");
 
     let mut i = 0;
     loop {
@@ -112,7 +112,7 @@ Note that this tool does not attempt to make sure that the files are entirely co
             binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
         }
 
-        if let Ok(source) = parser.to_source(&spec, &json) {
+        if let Ok(source) = parser.to_source(&spec, json) {
             i += 1;
 
             println!("Generated sample {}/{}", i, number);

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,19 @@
       "requires": {
         "shift-ast": "^4.0.0"
       }
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,11 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+    },
     "mktemp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "get-stdin": "^6.0.0",
     "mktemp": "^0.4.0",
     "shift-codegen": "^5.0.5",
-    "shift-parser": "^5.2.3"
+    "shift-parser": "^5.2.3",
+    "split": "^1.0.1"
   },
   "devDependencies": {},
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "get-stdin": "^6.0.0",
     "mktemp": "^0.4.0",
     "shift-codegen": "^5.0.5",
     "shift-parser": "^5.2.3"

--- a/src/bin/decode.rs
+++ b/src/bin/decode.rs
@@ -110,9 +110,9 @@ fn main() {
         root: &builder.node_name("Script"),
     };
     let spec = builder.into_spec(spec_options);
-    let printer = Shift::new();
+    let printer = Shift::try_new().expect("Could not launch Shift");
     let source = printer
-        .to_source(&spec, &json)
+        .to_source(&spec, json)
         .expect("Could not pretty-print");
 
     progress!(quiet, "Writing.");

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -296,7 +296,7 @@ fn main_aux() {
     let show_stats = matches.is_present("statistics");
 
     // Setup.
-    let parser = Shift::new();
+    let parser = Shift::try_new().expect("Could not launch Shift");
 
     let lazification =
         str::parse(matches.value_of("lazify").expect("Missing lazify")).expect("Invalid number");

--- a/src/bin/generate_dictionary.rs
+++ b/src/bin/generate_dictionary.rs
@@ -217,7 +217,7 @@ fn main_aux() {
     );
 
     // Setup.
-    let parser = Shift::new();
+    let parser = Shift::try_new().expect("Could not launch Shift");
     let mut dictionary = Dictionary::new(depth, width);
     let mut files_containing_string = KindedStringMap::default();
     let mut number_of_files = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ extern crate log;
 extern crate lzw;
 extern crate rand;
 extern crate vec_map;
+extern crate which;
 
 /// Working with a generic (i.e. JSON-based) representation
 /// of the JavaScript AST.

--- a/src/source/codegen.js
+++ b/src/source/codegen.js
@@ -1,3 +1,8 @@
+/**
+ * This CLI "daemon" expects Shift AST objects (in JSON format) on the stdin
+ * and will return a generated JS (as JSON strings) on stdout.
+ */
+
 'use strict';
 
 const codegen = require('shift-codegen').default;

--- a/src/source/codegen.js
+++ b/src/source/codegen.js
@@ -1,0 +1,7 @@
+var codegen = require('shift-codegen').default;
+var getStdin = require('get-stdin');
+
+getStdin().then(ast => {
+	var parsed = JSON.parse(ast);
+	process.stdout.write(codegen(parsed));
+});

--- a/src/source/codegen.js
+++ b/src/source/codegen.js
@@ -1,7 +1,6 @@
-var codegen = require('shift-codegen').default;
-var getStdin = require('get-stdin');
+'use strict';
 
-getStdin().then(ast => {
-	var parsed = JSON.parse(ast);
-	process.stdout.write(codegen(parsed));
-});
+const codegen = require('shift-codegen').default;
+const startJSONStream = require('./start-json-stream');
+
+startJSONStream(ast => codegen(ast));

--- a/src/source/escape_wtf8.js
+++ b/src/source/escape_wtf8.js
@@ -1,9 +1,0 @@
-module.exports = function (s) {
-	/* See crates/binjs_io/src/escaped_wtf8.rs */
-	return s.replace(/[\u007F\uD800-\uDFFF]/ug, function(m) {{
-		if (m == "\u007F") {{
-			return "\u007F007F";
-		}}
-		return "\u007F" + m.charCodeAt(0).toString(16);
-	}});
-}

--- a/src/source/escape_wtf8.js
+++ b/src/source/escape_wtf8.js
@@ -1,0 +1,9 @@
+module.exports = function (s) {
+	/* See crates/binjs_io/src/escaped_wtf8.rs */
+	return s.replace(/[\u007F\uD800-\uDFFF]/ug, function(m) {{
+		if (m == "\u007F") {{
+			return "\u007F007F";
+		}}
+		return "\u007F" + m.charCodeAt(0).toString(16);
+	}});
+}

--- a/src/source/parse_file.js
+++ b/src/source/parse_file.js
@@ -1,10 +1,10 @@
-var parseScript = require('shift-parser').parseScript;
-var getStdin = require('get-stdin');
-var escape = require('./escape_wtf8.js');
-var readFileSync = require('fs').readFileSync;
+'use strict';
 
-getStdin().then(filename => {
-	var data = readFileSync(filename, 'utf-8');
-	var parsed = parseScript(data, { earlyErrors: false });
-	process.stdout.write(escape(JSON.stringify(parsed)));
+const { readFileSync } = require('fs');
+const { parseScript } = require('shift-parser');
+const startJSONStream = require('./start-json-stream');
+
+startJSONStream(filename => {
+	let code = readFileSync(filename, 'utf-8');
+	return parseScript(code, { earlyErrors: false });
 });

--- a/src/source/parse_file.js
+++ b/src/source/parse_file.js
@@ -1,0 +1,10 @@
+var parseScript = require('shift-parser').parseScript;
+var getStdin = require('get-stdin');
+var escape = require('./escape_wtf8.js');
+var readFileSync = require('fs').readFileSync;
+
+getStdin().then(filename => {
+	var data = readFileSync(filename, 'utf-8');
+	var parsed = parseScript(data, { earlyErrors: false });
+	process.stdout.write(escape(JSON.stringify(parsed)));
+});

--- a/src/source/parse_file.js
+++ b/src/source/parse_file.js
@@ -1,4 +1,10 @@
-'use strict';
+/**
+ * This CLI "daemon" expects file paths to JavaScript files as JSON strings
+ * on the stdin and will parse them and produce Shift AST objects as JSON
+ * on stdout.
+ */
+
+ 'use strict';
 
 const { readFileSync } = require('fs');
 const { parseScript } = require('shift-parser');

--- a/src/source/parse_str.js
+++ b/src/source/parse_str.js
@@ -1,0 +1,8 @@
+var parseScript = require('shift-parser').parseScript;
+var getStdin = require('get-stdin');
+var escape = require('./escape_wtf8.js');
+
+getStdin().then(data => {
+	var parsed = parseScript(data, { earlyErrors: false });
+	process.stdout.write(escape(JSON.stringify(parsed)));
+});

--- a/src/source/parse_str.js
+++ b/src/source/parse_str.js
@@ -1,8 +1,6 @@
-var parseScript = require('shift-parser').parseScript;
-var getStdin = require('get-stdin');
-var escape = require('./escape_wtf8.js');
+'use strict';
 
-getStdin().then(data => {
-	var parsed = parseScript(data, { earlyErrors: false });
-	process.stdout.write(escape(JSON.stringify(parsed)));
-});
+const { parseScript } = require('shift-parser');
+const startJSONStream = require('./start-json-stream');
+
+startJSONStream(code => parseScript(code, { earlyErrors: false }));

--- a/src/source/parse_str.js
+++ b/src/source/parse_str.js
@@ -1,3 +1,8 @@
+/**
+ * This CLI "daemon" expects JSON strings containing JavaScript code on the
+ * stdin and will parse them and produce Shift AST objects as JSON on stdout.
+ */
+
 'use strict';
 
 const { parseScript } = require('shift-parser');

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -85,6 +85,14 @@ impl Script {
         })))
     }
 
+    /// This function is responsible for piping JSON inputs to the script
+    /// in a newline-delimited format and parsing JSON outputs back.
+    ///
+    /// Each output can be either `{"type":"Ok","value":...}` if operation was
+    /// successful or `{"type":"Err","value":...}` if corresponding JS callback
+    /// has failed with an error, and these are converted into Rust `Result`.
+    ///
+    /// See start-json-stream.js for some more details.
     pub fn transform(&self, input: &JSON) -> Result<JSON, Error> {
         let output = (move || {
             let mut io = self.0.lock().unwrap();

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -143,6 +143,11 @@ impl Shift {
         })
     }
 
+    // We need to mutate the AST to adjust it to the Shift format, so we take
+    // it by ownership rather than by reference.
+    //
+    // If the caller needs the original AST after this call, it's their
+    // responsibility to clone it and pass to this function.
     pub fn to_source(&self, syntax: &Spec, mut ast: JSON) -> Result<String, Error> {
         debug!(target: "Shift", "Preparing source\n{:#}", ast);
         let mut walker = MutASTWalker::new(syntax, ToShift);

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -30,8 +30,11 @@ pub enum Error {
 }
 
 pub struct NodeConfig {
+    /// Paths to the Node executable.
     bin_path: PathBuf,
+    /// Path to a directory with our Node.js scripts (same as this Rust file).
     scripts_path: &'static Path,
+    /// Node.js flag to configure memory usage.
     memory: OsString,
 }
 

--- a/src/source/start-json-stream.js
+++ b/src/source/start-json-stream.js
@@ -1,3 +1,13 @@
+/**
+ * This module is the primary entry point that takes care of communication
+ * with the Rust side over stdin and stdout pipes.
+ *
+ * Each pipe is expected to be an ND-JSON (newline-delimited JSON) message.
+ * Because we're not doing anything asynchronously, it's expected that after
+ * each input being sent over the stdin as a separate line, JS will produce
+ * an answer on stdout right after, also as a JSON value on a separate line.
+ */
+
 'use strict';
 
 const split = require('split');
@@ -14,6 +24,12 @@ function escapeWTF8(s) {
   });
 }
 
+/**
+ * This API should be called with a callback which simply accepts a parsed input
+ * and either returns an output value or throws.
+ *
+ * JSON parsing, serialisation and error handling will be taken care of.
+ */
 module.exports = mapper =>
   process.stdin
     .pipe(split(line => {

--- a/src/source/start-json-stream.js
+++ b/src/source/start-json-stream.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const split = require('split');
+
+// See crates/binjs_io/src/escaped_wtf8.rs
+function escapeWTF8(s) {
+  return s.replace(/[\u007F\uD800-\uDFFF]/gu, m => {
+    if (m == '\u007F') {
+      {
+        return '\u007F007F';
+      }
+    }
+    return '\u007F' + m.charCodeAt(0).toString(16);
+  });
+}
+
+module.exports = mapper =>
+  process.stdin
+    .pipe(
+      split(line => {
+        line = JSON.parse(line);
+        line = mapper(line);
+        line = escapeWTF8(JSON.stringify(line));
+        return line + '\n';
+      }, null, { trailing: false })
+    )
+    .pipe(process.stdout);

--- a/src/source/start-json-stream.js
+++ b/src/source/start-json-stream.js
@@ -16,12 +16,14 @@ function escapeWTF8(s) {
 
 module.exports = mapper =>
   process.stdin
-    .pipe(
-      split(line => {
+    .pipe(split(line => {
         line = JSON.parse(line);
-        line = mapper(line);
+        try {
+          line = { type: 'Ok', value: mapper(line) };
+        } catch (e) {
+          line = { type: 'Err', value: e.message };
+        }
         line = escapeWTF8(JSON.stringify(line));
         return line + '\n';
-      }, null, { trailing: false })
-    )
+      }, null, { trailing: false }))
     .pipe(process.stdout);

--- a/tests/test_dictionary_builder.rs
+++ b/tests/test_dictionary_builder.rs
@@ -29,7 +29,7 @@ impl Visitor<()> for OffsetCleanerVisitor {
 }
 
 test!(test_entropy_roundtrip, {
-    let parser = Shift::new();
+    let parser = Shift::try_new().expect("Could not launch Shift");
 
     let mut dictionary = Dictionary::new(3, 32);
     let mut files_containing_string = KindedStringMap::default();

--- a/tests/test_paths.rs
+++ b/tests/test_paths.rs
@@ -167,7 +167,9 @@ test!(test_es6_paths, {
     println!("Preparing test.");
 
     let trace = Rc::new(RefCell::new(vec![]));
-    let parser = Shift::new();
+
+    let parser = Shift::try_new().expect("Could not launch Shift");
+
     let writer = PathTraceWriter {
         trace: trace.clone(),
     };

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -71,7 +71,7 @@ fn main() {
 
     let mut rng = rand::thread_rng();
 
-    let parser = Shift::new();
+    let parser = Shift::try_new().expect("Could not launch Shift");
 
     // All combinations of options for compression.
     let mut all_options = {


### PR DESCRIPTION
This series of commits first simplifies parsing benchmarking to a trivial case to more reliably measure just the overhead of Rust -> Node.js interaction since it's the main contributor to performance issues when invoking Shift tasks.

Then, it changes previous model of running Node.js with given script as an input for each task, to spawning long-term Node.js "services" instead, with each script living in a separate file.

Before Node.js would just accept and spit either raw string or JSON. Now, all the communication is done via ND-JSON (newline-delimited JSON) streams, using the stdin/stdout pipes of the spawned process.

Also, before parsing or other errors would kill the process, dumping the error stack into stderr. This is fine for a single-run model, but not acceptable for long-living processes, so now instead each result of is wrapped into Rust's `Result`-like JSON enum `{"type":"Ok","value":...}` or `{"type":"Err","value":...}` and decoded back from that.

On the above mentioned benchmark, this brings 6x-7x improvement to a parsing speed on my machine, and the improvement is quite noticeable when running `cargo test` as well.