### PR TITLE
Support stable Rust and Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: rust
+cache:
+  - npm
+  - yarn
+  - cargo
 script:
   - cargo build --verbose
   - cargo test --all -- --nocapture
 rust:
-  - nightly
+  - stable
 node_js:
-  - "8"
+  - node

--- a/crates/binjs_es6/src/lib.rs
+++ b/crates/binjs_es6/src/lib.rs
@@ -1,6 +1,5 @@
 //! Strongly-typed implementation of the ES6 AST.
 
-#![feature(box_patterns)]
 #![recursion_limit="128"] // We have deeply nested data structures...
 
 #[macro_use]

--- a/crates/binjs_es6/src/scopes.rs
+++ b/crates/binjs_es6/src/scopes.rs
@@ -541,7 +541,7 @@ impl Visitor<()> for AnnotationVisitor {
     // Identifiers
 
     fn exit_call_expression(&mut self, _path: &WalkPath, node: &mut CallExpression) -> Result<Option<CallExpression>, ()> {
-        if let ExpressionOrSuper::IdentifierExpression(box ref id) = node.callee {
+        if let ExpressionOrSuper::IdentifierExpression(ref id) = node.callee {
             if id.name == "eval" {
                 *self.apparent_direct_eval_stack.last_mut()
                     .unwrap() = true;

--- a/crates/binjs_generate_library/src/lib.rs
+++ b/crates/binjs_generate_library/src/lib.rs
@@ -578,7 +578,7 @@ impl ToJSON for {name} {{
                                 cases = types
                                     .iter()
                                     .map(|case| {
-                                        format!("           {name}::{constructor}(box ref value) => value.export()",
+                                        format!("           {name}::{constructor}(ref value) => value.export()",
                                             name = name,
                                             constructor = case.to_class_cases())
                                     })
@@ -616,7 +616,7 @@ impl<'a, W> Serialization<W, &'a {rust_name}> for Serializer<W> where W: TokenWr
                             .iter()
                             .map(|case| {
                                 format!(
-"           {name}::{constructor}(box ref value) => {{
+"           {name}::{constructor}(ref value) => {{
                 // Path will be updated by the serializer for this tagged tuple.
                 (self as &mut Serialization<W, &'a {constructor}>).serialize(value, path)
             }}",
@@ -717,7 +717,7 @@ impl<'a> From<&'a mut {name}> for ViewMut{name}<'a> {{
                         name = name.to_class_cases(),
                         variants = types.iter()
                             .map(|variant| {
-                                format!("            {name}::{variant}(box ref mut x) => ViewMut{name}::{variant}(x),",
+                                format!("            {name}::{variant}(ref mut x) => ViewMut{name}::{variant}(x),",
                                     name = name.to_class_cases(),
                                     variant = variant.to_class_cases(),
                                 )

--- a/crates/binjs_generic/src/lib.rs
+++ b/crates/binjs_generic/src/lib.rs
@@ -1,8 +1,6 @@
 //! A crate containing tools to manipulate ASTs in generic (i.e. JSON)
 //! format.
 
-#![feature(box_patterns)]
-
 extern crate binjs_es6;
 extern crate binjs_io;
 extern crate binjs_meta;

--- a/crates/binjs_io/src/lib.rs
+++ b/crates/binjs_io/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(box_patterns)]
-#![feature(vec_resize_default)]
-
 extern crate bincode; // Used to store dictionaries. This is a temporary format.
 extern crate binjs_shared;
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@
 //! JavaScript format designed to optimize parsing speed and, when possible,
 //! loading speed.
 
-#![feature(box_patterns)]
-
 extern crate binjs_generic;
 extern crate binjs_es6;
 extern crate binjs_io;


### PR DESCRIPTION
Turns out, we don't really need the nightly features we've been relying on, so this should simplify average usage without opting in to quirks of nightly Rust.