### PR TITLE
Migrate from webidl to weedle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ lzw = "^0.10"
 rand = "^0.6"
 test-logger = "^0.1"
 vec_map = "^0.8"
-weedle = "^0.8"
 yaml-rust = "^0.4"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lzw = "^0.10"
 rand = "^0.6"
 test-logger = "^0.1"
 vec_map = "^0.8"
-webidl = "^0.8"
+weedle = "^0.8"
 yaml-rust = "^0.4"
 
 [[bin]]

--- a/crates/binjs_es6/Cargo.toml
+++ b/crates/binjs_es6/Cargo.toml
@@ -15,4 +15,4 @@ log = "^0.4"
 [build-dependencies]
 binjs_generate_library = { path = "../binjs_generate_library/", version = "*" }
 binjs_meta = { path = "../binjs_meta/", version = "*" }
-webidl = "^0.8"
+weedle = "^0.8"

--- a/crates/binjs_es6/Cargo.toml
+++ b/crates/binjs_es6/Cargo.toml
@@ -15,4 +15,3 @@ log = "^0.4"
 [build-dependencies]
 binjs_generate_library = { path = "../binjs_generate_library/", version = "*" }
 binjs_meta = { path = "../binjs_meta/", version = "*" }
-weedle = "^0.8"

--- a/crates/binjs_es6/build.rs
+++ b/crates/binjs_es6/build.rs
@@ -1,6 +1,5 @@
 extern crate binjs_generate_library;
 extern crate binjs_meta;
-extern crate weedle;
 
 use binjs_generate_library::*;
 use binjs_meta::import::Importer;
@@ -22,13 +21,11 @@ fn main() {
     file.read_to_string(&mut source)
         .expect("Could not read source");
 
-    let ast = weedle::parse(&source).expect("Could not parse source");
-
     // Check spec. We don't really need fake_root
     // for this operation. It may change in the future,
     // we'll see then.
 
-    let mut builder = Importer::import(&ast);
+    let mut builder = Importer::import(&source).expect("Could not parse source");
     let fake_root = builder.node_name("@@ROOT@@"); // Ignored.
     let null = builder.node_name(""); // Actually used
     builder.add_interface(&null).unwrap();

--- a/crates/binjs_es6/build.rs
+++ b/crates/binjs_es6/build.rs
@@ -1,6 +1,6 @@
 extern crate binjs_generate_library;
 extern crate binjs_meta;
-extern crate webidl;
+extern crate weedle;
 
 use binjs_generate_library::*;
 use binjs_meta::import::Importer;
@@ -22,7 +22,7 @@ fn main() {
     file.read_to_string(&mut source)
         .expect("Could not read source");
 
-    let ast = webidl::parse_string(&source).expect("Could not parse source");
+    let ast = weedle::parse(&source).expect("Could not parse source");
 
     // Check spec. We don't really need fake_root
     // for this operation. It may change in the future,

--- a/crates/binjs_generate_library/Cargo.toml
+++ b/crates/binjs_generate_library/Cargo.toml
@@ -11,5 +11,5 @@ log = "^0.4"
 
 [dev-dependencies]
 clap = "^2.0"
-webidl = "^0.8"
+weedle = "^0.8"
 yaml-rust = "^0.4"

--- a/crates/binjs_generate_library/Cargo.toml
+++ b/crates/binjs_generate_library/Cargo.toml
@@ -11,5 +11,4 @@ log = "^0.4"
 
 [dev-dependencies]
 clap = "^2.0"
-weedle = "^0.8"
 yaml-rust = "^0.4"

--- a/crates/binjs_generate_library/examples/generate_library.rs
+++ b/crates/binjs_generate_library/examples/generate_library.rs
@@ -2,7 +2,7 @@ extern crate binjs_generate_library;
 extern crate binjs_meta;
 extern crate clap;
 extern crate env_logger;
-extern crate webidl;
+extern crate weedle;
 
 use binjs_generate_library::*;
 use binjs_meta::import::Importer;
@@ -40,7 +40,7 @@ fn main() {
         .expect("Could not read source");
 
     println!("...parsing webidl");
-    let ast = webidl::parse_string(&source).expect("Could not parse source");
+    let ast = weedle::parse(&source).expect("Could not parse source");
 
     println!("...verifying grammar");
     let mut builder = Importer::import(&ast);

--- a/crates/binjs_generate_library/examples/generate_library.rs
+++ b/crates/binjs_generate_library/examples/generate_library.rs
@@ -2,7 +2,6 @@ extern crate binjs_generate_library;
 extern crate binjs_meta;
 extern crate clap;
 extern crate env_logger;
-extern crate weedle;
 
 use binjs_generate_library::*;
 use binjs_meta::import::Importer;
@@ -39,11 +38,8 @@ fn main() {
     file.read_to_string(&mut source)
         .expect("Could not read source");
 
-    println!("...parsing webidl");
-    let ast = weedle::parse(&source).expect("Could not parse source");
-
-    println!("...verifying grammar");
-    let mut builder = Importer::import(&ast);
+    println!("...importing webidl");
+    let mut builder = Importer::import(&source).expect("Could not parse source");
     let fake_root = builder.node_name("@@ROOT@@"); // Ignored.
     let null = builder.node_name(""); // Used.
     builder.add_interface(&null).unwrap();

--- a/crates/binjs_generic/Cargo.toml
+++ b/crates/binjs_generic/Cargo.toml
@@ -26,4 +26,3 @@ clap = "^2.0"
 [build-dependencies]
 binjs_generate_library = { path = "../binjs_generate_library", version = "*" }
 binjs_meta = { path = "../binjs_meta", version = "*" }
-weedle = "^0.8"

--- a/crates/binjs_generic/Cargo.toml
+++ b/crates/binjs_generic/Cargo.toml
@@ -26,4 +26,4 @@ clap = "^2.0"
 [build-dependencies]
 binjs_generate_library = { path = "../binjs_generate_library", version = "*" }
 binjs_meta = { path = "../binjs_meta", version = "*" }
-webidl = "^0.8"
+weedle = "^0.8"

--- a/crates/binjs_generic/build.rs
+++ b/crates/binjs_generic/build.rs
@@ -1,6 +1,5 @@
 extern crate binjs_generate_library;
 extern crate binjs_meta;
-extern crate weedle;
 
 use binjs_generate_library::*;
 use binjs_meta::import::Importer;
@@ -22,13 +21,11 @@ fn main() {
     file.read_to_string(&mut source)
         .expect("Could not read source");
 
-    let ast = weedle::parse(&source).expect("Could not parse source");
-
     // Check spec. We don't really need null/fake_root
     // for this operation. It may change in the future,
     // we'll see then.
 
-    let mut builder = Importer::import(&ast);
+    let mut builder = Importer::import(&source).expect("Could not parse source");
     let fake_root = builder.node_name(""); // Ignored.
     let null = builder.node_name("_Null"); // Ignored.
     builder.add_interface(&null).unwrap();

--- a/crates/binjs_generic/build.rs
+++ b/crates/binjs_generic/build.rs
@@ -1,6 +1,6 @@
 extern crate binjs_generate_library;
 extern crate binjs_meta;
-extern crate webidl;
+extern crate weedle;
 
 use binjs_generate_library::*;
 use binjs_meta::import::Importer;
@@ -22,7 +22,7 @@ fn main() {
     file.read_to_string(&mut source)
         .expect("Could not read source");
 
-    let ast = webidl::parse_string(&source).expect("Could not parse source");
+    let ast = weedle::parse(&source).expect("Could not parse source");
 
     // Check spec. We don't really need null/fake_root
     // for this operation. It may change in the future,

--- a/crates/binjs_meta/Cargo.toml
+++ b/crates/binjs_meta/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "https://github.com/binast/binjs-ref", branch = "mast
 Inflector = "^0.11"
 itertools = "^0.7"
 log = "^0.4"
-webidl = "^0.8"
+weedle = "^0.8"
 
 [dev-dependencies]
 clap = "^2.0"

--- a/crates/binjs_meta/examples/generate_spidermonkey.rs
+++ b/crates/binjs_meta/examples/generate_spidermonkey.rs
@@ -12,7 +12,7 @@ extern crate env_logger;
 extern crate itertools;
 #[macro_use]
 extern crate log;
-extern crate webidl;
+extern crate weedle;
 extern crate yaml_rust;
 
 use binjs_meta::export::{ToWebidl, TypeDeanonymizer, TypeName};
@@ -1611,7 +1611,7 @@ fn main() {
         .expect("Could not read source");
 
     println!("...parsing webidl");
-    let ast = webidl::parse_string(&source).expect("Could not parse source");
+    let ast = weedle::parse(&source).expect("Could not parse source");
 
     println!("...verifying grammar");
     let mut builder = Importer::import(&ast);

--- a/crates/binjs_meta/examples/generate_spidermonkey.rs
+++ b/crates/binjs_meta/examples/generate_spidermonkey.rs
@@ -12,7 +12,6 @@ extern crate env_logger;
 extern crate itertools;
 #[macro_use]
 extern crate log;
-extern crate weedle;
 extern crate yaml_rust;
 
 use binjs_meta::export::{ToWebidl, TypeDeanonymizer, TypeName};
@@ -1610,11 +1609,8 @@ fn main() {
     file.read_to_string(&mut source)
         .expect("Could not read source");
 
-    println!("...parsing webidl");
-    let ast = weedle::parse(&source).expect("Could not parse source");
-
-    println!("...verifying grammar");
-    let mut builder = Importer::import(&ast);
+    println!("...importing webidl");
+    let mut builder = Importer::import(&source).expect("Could not parse source");
     let fake_root = builder.node_name("@@ROOT@@"); // Unused
     let null = builder.node_name(""); // Used
     builder.add_interface(&null).unwrap();

--- a/crates/binjs_meta/src/import.rs
+++ b/crates/binjs_meta/src/import.rs
@@ -19,15 +19,13 @@ pub struct Importer {
 }
 
 impl Importer {
-    /// Import an AST into a SpecBuilder.
+    /// Import a WebIDL spec into a SpecBuilder.
     ///
     /// ```
     /// extern crate binjs_meta;
-    /// extern crate weedle;
-    /// use weedle;
     /// use binjs_meta::spec::SpecOptions;
     ///
-    /// let ast = weedle::parse("
+    /// let mut builder = binjs_meta::import::Importer::import("
     ///    interface FooContents {
     ///      attribute boolean value;
     ///    };
@@ -38,8 +36,6 @@ impl Importer {
     ///       attribute FooContents contents;
     ///    };
     /// ").expect("Could not parse");
-    ///
-    /// let mut builder = binjs_meta::import::Importer::import(&ast);
     ///
     /// let fake_root = builder.node_name("@@ROOT@@"); // Unused
     /// let null = builder.node_name(""); // Used
@@ -73,13 +69,14 @@ impl Importer {
     ///     assert_eq!(contents_field.is_lazy(), true);
     /// }
     /// ```
-    pub fn import(ast: &Definitions) -> SpecBuilder {
+    pub fn import(s: &str) -> Result<SpecBuilder, weedle::Err<CompleteStr>> {
         let mut importer = Importer {
             path: Vec::with_capacity(256),
             builder: SpecBuilder::new(),
         };
-        importer.import_all_definitions(ast);
-        importer.builder
+        let ast = weedle::parse(s)?;
+        importer.import_all_definitions(&ast);
+        Ok(importer.builder)
     }
 
     fn import_all_definitions(&mut self, ast: &Definitions) {

--- a/crates/binjs_meta/src/lib.rs
+++ b/crates/binjs_meta/src/lib.rs
@@ -6,7 +6,7 @@ extern crate itertools;
 
 #[macro_use]
 extern crate log;
-extern crate webidl;
+extern crate weedle;
 
 /// Generic tools for generating implementations of the Syntax.
 pub mod export;


### PR DESCRIPTION
This should significantly improve compilation times because `webidl` has `lalrpop` as a dependency which is pretty heavy and blows them up, whereas `weedle` uses just `nom` and so parses with pretty much pure Rust.

Some reference results from my machine with `cargo clean && cargo build -j4 [--release]`:

|         | `webidl` | `weedle` | diff    | diff (%) |
| ------- | -------- | -------- | ------- | -------- |
| debug   | 2m 34s   | 2m 01s   | -0m 33s | -21%     |
| release | 5m 43s   | 4m 37s   | -1m 06s | -19%     |

Initially inspired by https://github.com/rustwasm/wasm-bindgen/pull/639 which performed a similar migration.