### PR TITLE
Resolve #249 - Entropy 0.3 - the rest

### DIFF
--- a/crates/binjs_io/src/binjs_json/mod.rs
+++ b/crates/binjs_io/src/binjs_json/mod.rs
@@ -68,6 +68,7 @@ impl ::FormatProvider for FormatProvider {
 
     fn handle_subcommand(
         &self,
+        _spec: &binjs_meta::spec::Spec,
         _matches: Option<&clap::ArgMatches>,
     ) -> Result<::Format, ::std::io::Error> {
         Ok(::Format::JSON)

--- a/crates/binjs_io/src/entropy/predict.rs
+++ b/crates/binjs_io/src/entropy/predict.rs
@@ -3,7 +3,7 @@
 use entropy::probabilities::{InstancesToProbabilities, SymbolIndex, SymbolInfo};
 pub use io::statistics::Instances;
 
-use binjs_shared::{FieldName, IOPath, IOPathItem, InterfaceName};
+use binjs_shared::{IOPath, IOPathItem};
 
 use std;
 use std::borrow::Borrow;

--- a/crates/binjs_io/src/lib.rs
+++ b/crates/binjs_io/src/lib.rs
@@ -220,6 +220,7 @@ pub trait FormatProvider {
     /// Produce a format given command-line argument matches.
     fn handle_subcommand(
         &self,
+        spec: &binjs_meta::spec::Spec,
         matches: Option<&clap::ArgMatches>,
     ) -> Result<::Format, ::std::io::Error>;
 }
@@ -364,16 +365,19 @@ impl Format {
     /// Pick the first format provider that was invoked by
     /// `matches` as a subcommand. If none, pick the default
     /// provider, without any command-line arguments.
-    pub fn from_matches(matches: &clap::ArgMatches) -> Result<Self, std::io::Error> {
+    pub fn from_matches(
+        spec: &binjs_meta::spec::Spec,
+        matches: &clap::ArgMatches,
+    ) -> Result<Self, std::io::Error> {
         if let Some(matches) = matches.subcommand_matches(ADVANCED_COMMAND) {
             for provider in Self::providers().into_iter() {
                 let subcommand = provider.subcommand();
                 let key = subcommand.get_name();
                 if let Some(matches) = matches.subcommand_matches(key) {
-                    return provider.handle_subcommand(Some(matches));
+                    return provider.handle_subcommand(spec, Some(matches));
                 }
             }
         }
-        Self::default_provider().handle_subcommand(None)
+        Self::default_provider().handle_subcommand(spec, None)
     }
 }

--- a/crates/binjs_io/src/multipart/mod.rs
+++ b/crates/binjs_io/src/multipart/mod.rs
@@ -162,6 +162,7 @@ impl ::FormatProvider for FormatProvider {
 
     fn handle_subcommand(
         &self,
+        _spec: &binjs_meta::spec::Spec,
         matches: Option<&clap::ArgMatches>,
     ) -> Result<::Format, ::std::io::Error> {
         use bytes::compress::Compression;
@@ -228,7 +229,7 @@ fn test_multipart_io() {
             "{:?}-{:?}-{:?}",
             options.grammar_table, options.strings_table, options.tree
         );
-        let mut path = Path::new();
+        let path = Path::new();
 
         {
             options.reset();

--- a/crates/binjs_io/src/simple.rs
+++ b/crates/binjs_io/src/simple.rs
@@ -546,6 +546,7 @@ impl ::FormatProvider for FormatProvider {
 
     fn handle_subcommand(
         &self,
+        _spec: &binjs_meta::spec::Spec,
         _: Option<&clap::ArgMatches>,
     ) -> Result<::Format, ::std::io::Error> {
         Ok(::Format::Simple)

--- a/crates/binjs_io/src/xml.rs
+++ b/crates/binjs_io/src/xml.rs
@@ -163,6 +163,7 @@ impl ::FormatProvider for FormatProvider {
 
     fn handle_subcommand(
         &self,
+        _spec: &binjs_meta::spec::Spec,
         _matches: Option<&clap::ArgMatches>,
     ) -> Result<::Format, ::std::io::Error> {
         Ok(::Format::XML)

--- a/crates/binjs_shared/src/ast.rs
+++ b/crates/binjs_shared/src/ast.rs
@@ -96,6 +96,15 @@ where
 {
     // Nothing to do.
 }
+impl<I, F> std::fmt::Display for Path<I, F>
+where
+    I: Debug + Display,
+    F: Debug + Display,
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result {
+        self.items.fmt(formatter)
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Deserialize, Serialize)]
 pub struct PathItem<I, F>
@@ -261,3 +270,4 @@ pub trait Node: downcast_rs::Downcast {
     fn name(&self) -> &'static str;
 }
 impl_downcast!(Node);
+

--- a/crates/binjs_shared/src/ast.rs
+++ b/crates/binjs_shared/src/ast.rs
@@ -270,4 +270,3 @@ pub trait Node: downcast_rs::Downcast {
     fn name(&self) -> &'static str;
 }
 impl_downcast!(Node);
-

--- a/crates/binjs_shared/src/shared_string.rs
+++ b/crates/binjs_shared/src/shared_string.rs
@@ -82,7 +82,7 @@ impl SharedString {
     pub fn as_str(&self) -> &str {
         self.deref()
     }
-    pub fn from_str(value: &'static str) -> Self {
+    pub const fn from_str(value: &'static str) -> Self {
         SharedString::Static(value)
     }
     pub fn from_rc_string(value: Rc<String>) -> Self {
@@ -99,7 +99,7 @@ macro_rules! shared_string {
         #[derive(Clone, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize)]
         pub struct $name(pub shared_string::SharedString);
         impl $name {
-            pub fn from_str(value: &'static str) -> Self {
+            pub const fn from_str(value: &'static str) -> Self {
                 $name(shared_string::SharedString::from_str(value))
             }
             pub fn from_string(value: String) -> Self {
@@ -133,6 +133,11 @@ macro_rules! shared_string {
         impl Default for $name {
             fn default() -> Self {
                 Self::from_str("<uninitialized SharedString>")
+            }
+        }
+        impl std::fmt::Display for $name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+                self.as_str().fmt(formatter)
             }
         }
     };

--- a/examples/compare_compression.rs
+++ b/examples/compare_compression.rs
@@ -99,8 +99,11 @@ fn main() {
         .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
-    let mut format =
-        binjs::io::Format::from_matches(&matches).expect("Could not determine encoding format");
+    // Prepare grammar (used for entropy).
+    let spec = binjs::generic::es6::Library::spec();
+
+    let mut format = binjs::io::Format::from_matches(&spec, &matches)
+        .expect("Could not determine encoding format");
     println!("Using format: {}", format.name());
     println!(
         "Source files: {}",

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -58,7 +58,16 @@ Note that this tool does not attempt to make sure that the files are entirely co
 
     let mut rng = rand::thread_rng();
 
-    let mut format = binjs::io::Format::from_matches(&matches)
+    // Prepare grammar (used for entropy).
+    let mut builder = binjs::meta::spec::SpecBuilder::new();
+    let _ = binjs::generic::es6::Library::new(&mut builder);
+    let spec_options = binjs::meta::spec::SpecOptions {
+        null: &builder.node_name(""),
+        root: &builder.node_name("Script"),
+    };
+    let spec = builder.into_spec(spec_options);
+
+    let mut format = binjs::io::Format::from_matches(&spec, &matches)
         .expect("Could not determine encoding format")
         .randomize_options(&mut rng);
 
@@ -79,12 +88,7 @@ Note that this tool does not attempt to make sure that the files are entirely co
         Some(size) => size.parse().expect("Invalid size"),
     };
 
-    let mut builder = binjs::meta::spec::SpecBuilder::new();
-    let library = binjs::generic::es6::Library::new(&mut builder);
-    let spec = builder.into_spec(binjs::meta::spec::SpecOptions {
-        root: &library.program,
-        null: &library.null,
-    });
+    let spec = binjs::generic::es6::Library::spec();
 
     let random_metadata = matches.is_present("random-metadata");
 

--- a/src/bin/convert_from_json.rs
+++ b/src/bin/convert_from_json.rs
@@ -167,8 +167,9 @@ fn main_aux() {
         .get_matches();
 
     // Format options.
+    let spec = binjs::generic::es6::Library::spec();
     let mut format =
-        binjs::io::Format::from_matches(&matches).expect("Could not parse encoding format");
+        binjs::io::Format::from_matches(&spec, &matches).expect("Could not parse encoding format");
 
     let mut reader = binjs::io::binjs_json::read::Decoder::new(stdin()).expect("Failed to parse");
 

--- a/src/bin/decode.rs
+++ b/src/bin/decode.rs
@@ -62,6 +62,15 @@ fn main() {
         .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
+    // Prepare grammar (used for entropy).
+    let mut builder = binjs::meta::spec::SpecBuilder::new();
+    let _ = binjs::generic::es6::Library::new(&mut builder);
+    let spec_options = binjs::meta::spec::SpecOptions {
+        null: &builder.node_name(""),
+        root: &builder.node_name("Script"),
+    };
+    let spec = builder.into_spec(spec_options);
+
     // Common options.
     let source_path = matches.value_of("INPUT");
     let dest_path = matches.value_of("OUTPUT");
@@ -69,7 +78,7 @@ fn main() {
 
     // Format options.
     let format =
-        binjs::io::Format::from_matches(&matches).expect("Could not parse encoding format");
+        binjs::io::Format::from_matches(&spec, &matches).expect("Could not parse encoding format");
     progress!(quiet, "Using format: {}", format.name());
 
     // Setup.
@@ -103,13 +112,6 @@ fn main() {
     }
 
     progress!(quiet, "Pretty-printing");
-    let mut builder = binjs::meta::spec::SpecBuilder::new();
-    let _ = binjs::generic::es6::Library::new(&mut builder);
-    let spec_options = binjs::meta::spec::SpecOptions {
-        null: &builder.node_name(""),
-        root: &builder.node_name("Script"),
-    };
-    let spec = builder.into_spec(spec_options);
     let printer = Shift::try_new().expect("Could not launch Shift");
     let source = printer
         .to_source(&spec, json)

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -275,6 +275,9 @@ fn main_aux() {
         .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
+    // Prepare grammar (used for entropy).
+    let spec = binjs::generic::es6::Library::spec();
+
     // Common options.
     let sources: Vec<_> = matches
         .values_of("in")
@@ -295,7 +298,7 @@ fn main_aux() {
 
     // Format options.
     let format =
-        binjs::io::Format::from_matches(&matches).expect("Could not parse encoding format");
+        binjs::io::Format::from_matches(&spec, &matches).expect("Could not parse encoding format");
     progress!(quiet, "Using format: {}", format.name());
 
     let show_stats = matches.is_present("statistics");


### PR DESCRIPTION
This finishes connecting all the bits and pieces of Entropy 0.3.

With this PR, the compressor can finally compress data whose grammar constructions do not show up in the samples. In particular, this means that we can (poorly) compress without dictionary.