### PR TITLE
Use lazy_static for parser reuse in benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ which = "^2.0"
 [dev-dependencies]
 bencher = "^0.1"
 glob = "^0.2"
+lazy_static = "^1.2"
 tempdir = "^0.3"
 test-logger = { version = "^0.1", git = "https://github.com/RReverser/test-logger" }
 yaml-rust = "^0.4"

--- a/benches/bench_fb.rs
+++ b/benches/bench_fb.rs
@@ -6,6 +6,8 @@ extern crate binjs;
 
 extern crate glob;
 extern crate itertools;
+#[macro_use]
+extern crate lazy_static;
 
 use binjs::generic::*;
 use binjs::source::*;
@@ -19,12 +21,16 @@ fn launch_shift() -> Shift {
     Shift::try_new().expect("Could not launch Shift")
 }
 
+lazy_static! {
+    static ref SHIFT: Shift = launch_shift();
+}
+
 fn bench_parsing_one_parser_per_run(bencher: &mut bencher::Bencher) {
     bench_parsing_aux(None, bencher);
 }
 
 fn bench_parsing_reuse_parser(bencher: &mut bencher::Bencher) {
-    bench_parsing_aux(Some(&launch_shift()), bencher);
+    bench_parsing_aux(Some(&SHIFT), bencher);
 }
 
 fn bench_parsing_aux(parser: Option<&Shift>, bencher: &mut bencher::Bencher) {


### PR DESCRIPTION
So... this was surprising and took me a long time to figure out, but apparently background Node.js processes affect bencher even if they're being shut down outside of the measurement code.

I don't know why exactly or how this happens, but even adding `.wait()` in drop code didn't help, so now I'm using a single shared parser for the `bench_parsing_reuse_parser`.

Before: 25,043,240 ns/iter (+/- 3,170,399)
After: 276,631 ns/iter (+/- 72,568)