### PR TITLE
Issue #296 - Extending the webidl with a secondary file.

### DIFF
--- a/crates/binjs_es6/build.rs
+++ b/crates/binjs_es6/build.rs
@@ -9,23 +9,33 @@ use std::env;
 use std::fs::*;
 use std::io::*;
 
-const PATH_GRAMMAR_ES6: &'static str = "../../spec/es6.webidl";
+/// The webidl source files.
+///
+/// Order is important: first the main file, then any extension.
+const PATH_SOURCES: [&'static str; 2] =
+    ["../../spec/es6.webidl", "../../spec/es6-extension.webidl"];
 
 fn main() {
-    println!("cargo:rerun-if-changed={}", PATH_GRAMMAR_ES6);
+    for source in &PATH_SOURCES {
+        println!("cargo:rerun-if-changed={}", source);
+    }
 
     // Load webidl.
 
-    let mut file = File::open(PATH_GRAMMAR_ES6).expect("Could not open source");
-    let mut source = String::new();
-    file.read_to_string(&mut source)
-        .expect("Could not read source");
+    let sources: Vec<_> = PATH_SOURCES
+        .iter()
+        .map(|path| {
+            read_to_string(path)
+                .unwrap_or_else(|e| panic!("Could not open grammar file {}: {}", path, e))
+        })
+        .collect();
+    let sources = sources.iter().map(String::as_str);
 
     // Check spec. We don't really need fake_root
     // for this operation. It may change in the future,
     // we'll see then.
 
-    let mut builder = Importer::import(&source).expect("Could not parse source");
+    let mut builder = Importer::import(sources).expect("Could not parse webidl sources");
     let fake_root = builder.node_name("@@ROOT@@"); // Ignored.
     let null = builder.node_name(""); // Actually used
     builder.add_interface(&null).unwrap();

--- a/crates/binjs_generate_library/examples/generate_library.rs
+++ b/crates/binjs_generate_library/examples/generate_library.rs
@@ -39,7 +39,8 @@ fn main() {
         .expect("Could not read source");
 
     println!("...importing webidl");
-    let mut builder = Importer::import(&source).expect("Could not parse source");
+    let mut builder =
+        Importer::import(vec![source.as_str()].into_iter()).expect("Could not parse source");
     let fake_root = builder.node_name("@@ROOT@@"); // Ignored.
     let null = builder.node_name(""); // Used.
     builder.add_interface(&null).unwrap();

--- a/crates/binjs_meta/examples/generate_spidermonkey.rs
+++ b/crates/binjs_meta/examples/generate_spidermonkey.rs
@@ -1610,7 +1610,8 @@ fn main() {
         .expect("Could not read source");
 
     println!("...importing webidl");
-    let mut builder = Importer::import(&source).expect("Could not parse source");
+    let mut builder =
+        Importer::import(vec![source.as_str()].into_iter()).expect("Could not parse source");
     let fake_root = builder.node_name("@@ROOT@@"); // Unused
     let null = builder.node_name(""); // Used
     builder.add_interface(&null).unwrap();

--- a/crates/binjs_meta/src/spec.rs
+++ b/crates/binjs_meta/src/spec.rs
@@ -116,6 +116,13 @@ impl TypeSum {
         }
         None
     }
+
+    /// Add a new type case to this sum.
+    pub fn with_type_case(&mut self, spec: TypeSpec) -> &mut Self {
+        debug_assert_eq!(self.interfaces.len(), 0);
+        self.types.push(spec);
+        self
+    }
 }
 
 /// Representation of a field in an interface.
@@ -720,8 +727,14 @@ impl SpecBuilder {
         self.typedefs_by_name.get(name).map(RefCell::borrow_mut)
     }
 
+    /// Access an already added typedef.
     pub fn get_typedef(&self, name: &NodeName) -> Option<Ref<Type>> {
         self.typedefs_by_name.get(name).map(RefCell::borrow)
+    }
+
+    /// Access an already added typedef, mutably.
+    pub fn get_typedef_mut(&mut self, name: &NodeName) -> Option<RefMut<Type>> {
+        self.typedefs_by_name.get(name).map(RefCell::borrow_mut)
     }
 
     /// Generate the graph.

--- a/spec/es6-extension.webidl
+++ b/spec/es6-extension.webidl
@@ -1,0 +1,27 @@
+// Extensions to the webidl.
+//
+// These extensions are not part of the AST spec, but of the compression mechanism.
+
+[ExtendsTypeSum=Expression]
+// An extension to `Expression` used to locally change probability tables.
+//
+// Instances of `BinASTExpressionWithProbabilityTable` are designed to
+// be inserted during compression and erased during decompression.
+//
+// In terms of semantics, an instance of
+// `BinASTExpressionWithProbabilityTable { table: _, expression: e }`
+// is equivalent to `e`.
+interface BinASTExpressionWithProbabilityTable {
+    // The name of the probability table to use (e.g. `main`, `json`).
+    //
+    // The list of probability tables is not specified as part of the grammar.
+    // Rather, individual compression dictionaries may define separate probability
+    // tables.
+    //
+    // Attempting to (de)compress with a probability table that does not
+    // appear in the dictionary is a (de)compression error.
+    attribute string table;
+
+    // The actual expression.
+    attribute Expression expression;
+};


### PR DESCRIPTION
This patch adds support for extending es6.webidl with an additional file es6-extension.webidl. The role of that file is to modify the AST in a manner that is useful for *compression* but has no impact on visible *syntax and semantics* of the language. In other words, es6.webidl is meant to be part of the BinAST language specification, while es6-extension.webidl is meant to be part of the compression format.

The main objective of this patch is to let us adopt specialized compression dictionaries for e.g. JSON, arithmetic expressions, etc.