### PR TITLE
Remove lifetime from Serialization trait

### DIFF
--- a/crates/binjs_es6/src/io.rs
+++ b/crates/binjs_es6/src/io.rs
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<R> Deserialization<R, Option<bool>> for Deserializer<R>
+impl<R> Deserialization<Option<bool>> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -41,7 +41,7 @@ where
         self.reader.bool_at(path)
     }
 }
-impl<R> Deserialization<R, bool> for Deserializer<R>
+impl<R> Deserialization<bool> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -53,7 +53,7 @@ where
         }
     }
 }
-impl<R> Deserialization<R, Option<f64>> for Deserializer<R>
+impl<R> Deserialization<Option<f64>> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -61,7 +61,7 @@ where
         self.reader.float_at(path)
     }
 }
-impl<R> Deserialization<R, f64> for Deserializer<R>
+impl<R> Deserialization<f64> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -73,7 +73,7 @@ where
         }
     }
 }
-impl<R> Deserialization<R, u32> for Deserializer<R>
+impl<R> Deserialization<u32> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -81,7 +81,7 @@ where
         self.reader.unsigned_long_at(path)
     }
 }
-impl<R> Deserialization<R, Offset> for Deserializer<R>
+impl<R> Deserialization<Offset> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -89,7 +89,7 @@ where
         Ok(Offset(self.reader.offset_at(path)?))
     }
 }
-impl<R> Deserialization<R, Option<SharedString>> for Deserializer<R>
+impl<R> Deserialization<Option<SharedString>> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -97,7 +97,7 @@ where
         self.reader.string_at(path)
     }
 }
-impl<R> Deserialization<R, SharedString> for Deserializer<R>
+impl<R> Deserialization<SharedString> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -109,7 +109,7 @@ where
         }
     }
 }
-impl<R> Deserialization<R, IdentifierName> for Deserializer<R>
+impl<R> Deserialization<IdentifierName> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -119,7 +119,7 @@ where
             .ok_or_else(|| From::from(TokenReaderError::EmptyString))
     }
 }
-impl<R> Deserialization<R, PropertyKey> for Deserializer<R>
+impl<R> Deserialization<PropertyKey> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -130,7 +130,7 @@ where
     }
 }
 
-impl<R> Deserialization<R, Option<IdentifierName>> for Deserializer<R>
+impl<R> Deserialization<Option<IdentifierName>> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -141,7 +141,7 @@ where
         self.reader.identifier_name_at(path)
     }
 }
-impl<R> Deserialization<R, Option<PropertyKey>> for Deserializer<R>
+impl<R> Deserialization<Option<PropertyKey>> for Deserializer<R>
 where
     R: TokenReader,
 {
@@ -150,10 +150,10 @@ where
     }
 }
 
-impl<R, T> Deserialization<R, Vec<T>> for Deserializer<R>
+impl<R, T> Deserialization<Vec<T>> for Deserializer<R>
 where
     R: TokenReader,
-    Self: Deserialization<R, T>,
+    Self: Deserialization<T>,
 {
     fn deserialize(&mut self, path: &mut IOPath) -> Result<Vec<T>, TokenReaderError> {
         let len = self.reader.enter_list_at(path)?;
@@ -201,7 +201,7 @@ where
     }
 }
 
-impl<W> Serialization<W, Option<bool>> for Serializer<W>
+impl<W> Serialization<Option<bool>> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -213,7 +213,7 @@ where
         self.writer.bool_at(*value, path)
     }
 }
-impl<W> Serialization<W, bool> for Serializer<W>
+impl<W> Serialization<bool> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -221,7 +221,7 @@ where
         self.writer.bool_at(Some(*value), path)
     }
 }
-impl<W> Serialization<W, Option<f64>> for Serializer<W>
+impl<W> Serialization<Option<f64>> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -233,7 +233,7 @@ where
         self.writer.float_at(*value, path)
     }
 }
-impl<W> Serialization<W, f64> for Serializer<W>
+impl<W> Serialization<f64> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -241,7 +241,7 @@ where
         self.writer.float_at(Some(*value), path)
     }
 }
-impl<W> Serialization<W, u32> for Serializer<W>
+impl<W> Serialization<u32> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -249,7 +249,7 @@ where
         self.writer.unsigned_long_at(*value, path)
     }
 }
-impl<W> Serialization<W, SharedString> for Serializer<W>
+impl<W> Serialization<SharedString> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -261,7 +261,7 @@ where
         self.writer.string_at(Some(value), path)
     }
 }
-impl<W> Serialization<W, Option<SharedString>> for Serializer<W>
+impl<W> Serialization<Option<SharedString>> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -273,7 +273,7 @@ where
         self.writer.string_at(value.as_ref(), path)
     }
 }
-impl<W> Serialization<W, IdentifierName> for Serializer<W>
+impl<W> Serialization<IdentifierName> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -285,7 +285,7 @@ where
         self.writer.identifier_name_at(Some(&value), path)
     }
 }
-impl<W> Serialization<W, PropertyKey> for Serializer<W>
+impl<W> Serialization<PropertyKey> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -297,7 +297,7 @@ where
         self.writer.property_key_at(Some(&value), path)
     }
 }
-impl<W> Serialization<W, Option<IdentifierName>> for Serializer<W>
+impl<W> Serialization<Option<IdentifierName>> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -309,7 +309,7 @@ where
         self.writer.identifier_name_at(value.as_ref(), path)
     }
 }
-impl<W> Serialization<W, Option<PropertyKey>> for Serializer<W>
+impl<W> Serialization<Option<PropertyKey>> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -321,7 +321,7 @@ where
         self.writer.property_key_at(value.as_ref(), path)
     }
 }
-impl<W> Serialization<W, Offset> for Serializer<W>
+impl<W> Serialization<Offset> for Serializer<W>
 where
     W: TokenWriter,
 {
@@ -329,11 +329,11 @@ where
         self.writer.offset_at(path)
     }
 }
-impl<W, T> Serialization<W, Box<T>> for Serializer<W>
+impl<W, T> Serialization<Box<T>> for Serializer<W>
 where
     W: TokenWriter,
     T: ?Sized,
-    Self: Serialization<W, T>,
+    Self: Serialization<T>,
 {
     fn serialize(&mut self, value: &Box<T>, path: &mut IOPath) -> Result<(), TokenWriterError> {
         self.serialize(value.as_ref(), path)
@@ -345,20 +345,16 @@ impl Decoder {
     pub fn new() -> Self {
         Decoder
     }
-    pub fn decode<'a, R: Read + Seek, AST>(
+    pub fn decode<R: Read + Seek, AST>(
         &self,
-        format: &'a mut binjs_io::Format,
+        format: &mut binjs_io::Format,
         source: R,
     ) -> Result<AST, TokenReaderError>
     where
-        Deserializer<binjs_io::simple::TreeTokenReader<R>>:
-            Deserialization<binjs_io::simple::TreeTokenReader<R>, AST>,
-        Deserializer<binjs_io::multipart::TreeTokenReader>:
-            Deserialization<binjs_io::multipart::TreeTokenReader, AST>,
-        Deserializer<binjs_io::binjs_json::read::Decoder<R>>:
-            Deserialization<binjs_io::binjs_json::read::Decoder<R>, AST>,
-        Deserializer<binjs_io::entropy::read::Decoder>:
-            Deserialization<binjs_io::entropy::read::Decoder, AST>,
+        Deserializer<binjs_io::simple::TreeTokenReader<R>>: Deserialization<AST>,
+        Deserializer<binjs_io::multipart::TreeTokenReader>: Deserialization<AST>,
+        Deserializer<binjs_io::binjs_json::read::Decoder<R>>: Deserialization<AST>,
+        Deserializer<binjs_io::entropy::read::Decoder>: Deserialization<AST>,
     {
         let mut path = IOPath::new();
         match *format {
@@ -395,23 +391,19 @@ impl Encoder {
     pub fn new() -> Self {
         Encoder
     }
-    pub fn encode<'a, AST>(
+    pub fn encode<AST>(
         &self,
         path: Option<&std::path::Path>,
-        format: &'a mut binjs_io::Format,
-        ast: &'a AST,
+        format: &mut binjs_io::Format,
+        ast: &AST,
     ) -> Result<Box<AsRef<[u8]>>, TokenWriterError>
     where
-        Serializer<TokenWriterTreeAdapter<binjs_io::simple::TreeTokenWriter>>:
-            Serialization<TokenWriterTreeAdapter<binjs_io::simple::TreeTokenWriter>, AST>,
+        Serializer<TokenWriterTreeAdapter<binjs_io::simple::TreeTokenWriter>>: Serialization<AST>,
         Serializer<TokenWriterTreeAdapter<binjs_io::multipart::TreeTokenWriter>>:
-            Serialization<TokenWriterTreeAdapter<binjs_io::multipart::TreeTokenWriter>, AST>,
-        Serializer<TokenWriterTreeAdapter<binjs_io::xml::Encoder>>:
-            Serialization<TokenWriterTreeAdapter<binjs_io::xml::Encoder>, AST>,
-        Serializer<binjs_io::binjs_json::write::TreeTokenWriter>:
-            Serialization<binjs_io::binjs_json::write::TreeTokenWriter, AST>,
-        Serializer<binjs_io::entropy::write::Encoder>:
-            Serialization<binjs_io::entropy::write::Encoder, AST>,
+            Serialization<AST>,
+        Serializer<TokenWriterTreeAdapter<binjs_io::xml::Encoder>>: Serialization<AST>,
+        Serializer<binjs_io::binjs_json::write::TreeTokenWriter>: Serialization<AST>,
+        Serializer<binjs_io::entropy::write::Encoder>: Serialization<AST>,
     {
         let mut io_path = IOPath::new();
         match *format {

--- a/crates/binjs_es6/src/io.rs
+++ b/crates/binjs_es6/src/io.rs
@@ -190,12 +190,6 @@ where
     pub fn new(writer: W) -> Self {
         Self { writer }
     }
-    pub fn serialize<T>(&mut self, value: T, path: &mut IOPath) -> Result<(), TokenWriterError>
-    where
-        Self: Serialization<W, T>,
-    {
-        (self as &mut Serialization<W, T>).serialize(value, path)
-    }
 }
 
 impl<W> TokenSerializer<W> for Serializer<W>
@@ -213,182 +207,136 @@ where
 {
     fn serialize(
         &mut self,
-        value: Option<bool>,
+        value: &Option<bool>,
         path: &mut IOPath,
     ) -> Result<(), TokenWriterError> {
-        self.writer.bool_at(value, path)
+        self.writer.bool_at(*value, path)
     }
 }
 impl<W> Serialization<W, bool> for Serializer<W>
 where
     W: TokenWriter,
 {
-    fn serialize(&mut self, value: bool, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.bool_at(Some(value), path)
+    fn serialize(&mut self, value: &bool, path: &mut IOPath) -> Result<(), TokenWriterError> {
+        self.writer.bool_at(Some(*value), path)
     }
 }
 impl<W> Serialization<W, Option<f64>> for Serializer<W>
 where
     W: TokenWriter,
 {
-    fn serialize(&mut self, value: Option<f64>, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.float_at(value, path)
+    fn serialize(
+        &mut self,
+        value: &Option<f64>,
+        path: &mut IOPath,
+    ) -> Result<(), TokenWriterError> {
+        self.writer.float_at(*value, path)
     }
 }
 impl<W> Serialization<W, f64> for Serializer<W>
 where
     W: TokenWriter,
 {
-    fn serialize(&mut self, value: f64, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.float_at(Some(value), path)
+    fn serialize(&mut self, value: &f64, path: &mut IOPath) -> Result<(), TokenWriterError> {
+        self.writer.float_at(Some(*value), path)
     }
 }
 impl<W> Serialization<W, u32> for Serializer<W>
 where
     W: TokenWriter,
 {
-    fn serialize(&mut self, value: u32, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.unsigned_long_at(value, path)
+    fn serialize(&mut self, value: &u32, path: &mut IOPath) -> Result<(), TokenWriterError> {
+        self.writer.unsigned_long_at(*value, path)
     }
 }
-impl<'a, W> Serialization<W, &'a Option<bool>> for Serializer<W>
+impl<W> Serialization<W, SharedString> for Serializer<W>
 where
     W: TokenWriter,
 {
     fn serialize(
         &mut self,
-        value: &'a Option<bool>,
-        path: &mut IOPath,
-    ) -> Result<(), TokenWriterError> {
-        self.writer.bool_at(value.clone(), path)
-    }
-}
-impl<'a, W> Serialization<W, &'a bool> for Serializer<W>
-where
-    W: TokenWriter,
-{
-    fn serialize(&mut self, value: &'a bool, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.bool_at(Some(*value), path)
-    }
-}
-impl<'a, W> Serialization<W, &'a Option<f64>> for Serializer<W>
-where
-    W: TokenWriter,
-{
-    fn serialize(
-        &mut self,
-        value: &'a Option<f64>,
-        path: &mut IOPath,
-    ) -> Result<(), TokenWriterError> {
-        self.writer.float_at(value.clone(), path)
-    }
-}
-impl<'a, W> Serialization<W, &'a f64> for Serializer<W>
-where
-    W: TokenWriter,
-{
-    fn serialize(&mut self, value: &'a f64, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.float_at(Some(*value), path)
-    }
-}
-impl<'a, W> Serialization<W, &'a u32> for Serializer<W>
-where
-    W: TokenWriter,
-{
-    fn serialize(&mut self, value: &'a u32, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.unsigned_long_at(value.clone(), path)
-    }
-}
-/*
-impl<'a, W> Serialization<W, Option<&'a str>> for Serializer<W> where W: TokenWriter {
-    fn serialize(&mut self, value: Option<&'a str>, path: &mut IOPath) -> Result<(), TokenWriterError> {
-        self.writer.string_at(value, path)
-    }
-}
-impl<'a, W> Serialization<W, &'a str> for Serializer<W> where W: TokenWriter {
-    fn serialize(&mut self, value: &'a str, path: &mut IOPath) -> Result<(), TokenWriterError> {
-         self.writer.string_at(Some(value), path)
-   }
-}
-*/
-impl<'a, W> Serialization<W, &'a SharedString> for Serializer<W>
-where
-    W: TokenWriter,
-{
-    fn serialize(
-        &mut self,
-        value: &'a SharedString,
+        value: &SharedString,
         path: &mut IOPath,
     ) -> Result<(), TokenWriterError> {
         self.writer.string_at(Some(value), path)
     }
 }
-impl<'a, W> Serialization<W, &'a Option<SharedString>> for Serializer<W>
+impl<W> Serialization<W, Option<SharedString>> for Serializer<W>
 where
     W: TokenWriter,
 {
     fn serialize(
         &mut self,
-        value: &'a Option<SharedString>,
+        value: &Option<SharedString>,
         path: &mut IOPath,
     ) -> Result<(), TokenWriterError> {
         self.writer.string_at(value.as_ref(), path)
     }
 }
-impl<'a, W> Serialization<W, &'a IdentifierName> for Serializer<W>
+impl<W> Serialization<W, IdentifierName> for Serializer<W>
 where
     W: TokenWriter,
 {
     fn serialize(
         &mut self,
-        value: &'a IdentifierName,
+        value: &IdentifierName,
         path: &mut IOPath,
     ) -> Result<(), TokenWriterError> {
         self.writer.identifier_name_at(Some(&value), path)
     }
 }
-impl<'a, W> Serialization<W, &'a PropertyKey> for Serializer<W>
+impl<W> Serialization<W, PropertyKey> for Serializer<W>
 where
     W: TokenWriter,
 {
     fn serialize(
         &mut self,
-        value: &'a PropertyKey,
+        value: &PropertyKey,
         path: &mut IOPath,
     ) -> Result<(), TokenWriterError> {
         self.writer.property_key_at(Some(&value), path)
     }
 }
-impl<'a, W> Serialization<W, &'a Option<IdentifierName>> for Serializer<W>
+impl<W> Serialization<W, Option<IdentifierName>> for Serializer<W>
 where
     W: TokenWriter,
 {
     fn serialize(
         &mut self,
-        value: &'a Option<IdentifierName>,
+        value: &Option<IdentifierName>,
         path: &mut IOPath,
     ) -> Result<(), TokenWriterError> {
         self.writer.identifier_name_at(value.as_ref(), path)
     }
 }
-impl<'a, W> Serialization<W, &'a Option<PropertyKey>> for Serializer<W>
+impl<W> Serialization<W, Option<PropertyKey>> for Serializer<W>
 where
     W: TokenWriter,
 {
     fn serialize(
         &mut self,
-        value: &'a Option<PropertyKey>,
+        value: &Option<PropertyKey>,
         path: &mut IOPath,
     ) -> Result<(), TokenWriterError> {
         self.writer.property_key_at(value.as_ref(), path)
     }
 }
-impl<'a, W> Serialization<W, &'a Offset> for Serializer<W>
+impl<W> Serialization<W, Offset> for Serializer<W>
 where
     W: TokenWriter,
 {
-    fn serialize(&mut self, _: &'a Offset, path: &mut IOPath) -> Result<(), TokenWriterError> {
+    fn serialize(&mut self, _: &Offset, path: &mut IOPath) -> Result<(), TokenWriterError> {
         self.writer.offset_at(path)
+    }
+}
+impl<W, T> Serialization<W, Box<T>> for Serializer<W>
+where
+    W: TokenWriter,
+    T: ?Sized,
+    Self: Serialization<W, T>,
+{
+    fn serialize(&mut self, value: &Box<T>, path: &mut IOPath) -> Result<(), TokenWriterError> {
+        self.serialize(value.as_ref(), path)
     }
 }
 
@@ -455,15 +403,15 @@ impl Encoder {
     ) -> Result<Box<AsRef<[u8]>>, TokenWriterError>
     where
         Serializer<TokenWriterTreeAdapter<binjs_io::simple::TreeTokenWriter>>:
-            Serialization<TokenWriterTreeAdapter<binjs_io::simple::TreeTokenWriter>, &'a AST>,
+            Serialization<TokenWriterTreeAdapter<binjs_io::simple::TreeTokenWriter>, AST>,
         Serializer<TokenWriterTreeAdapter<binjs_io::multipart::TreeTokenWriter>>:
-            Serialization<TokenWriterTreeAdapter<binjs_io::multipart::TreeTokenWriter>, &'a AST>,
+            Serialization<TokenWriterTreeAdapter<binjs_io::multipart::TreeTokenWriter>, AST>,
         Serializer<TokenWriterTreeAdapter<binjs_io::xml::Encoder>>:
-            Serialization<TokenWriterTreeAdapter<binjs_io::xml::Encoder>, &'a AST>,
+            Serialization<TokenWriterTreeAdapter<binjs_io::xml::Encoder>, AST>,
         Serializer<binjs_io::binjs_json::write::TreeTokenWriter>:
-            Serialization<binjs_io::binjs_json::write::TreeTokenWriter, &'a AST>,
+            Serialization<binjs_io::binjs_json::write::TreeTokenWriter, AST>,
         Serializer<binjs_io::entropy::write::Encoder>:
-            Serialization<binjs_io::entropy::write::Encoder, &'a AST>,
+            Serialization<binjs_io::entropy::write::Encoder, AST>,
     {
         let mut io_path = IOPath::new();
         match *format {

--- a/crates/binjs_generate_library/src/lib.rs
+++ b/crates/binjs_generate_library/src/lib.rs
@@ -306,8 +306,8 @@ impl FromJSON for {name} {{
 
                 let to_writer = format!(
                     "
-impl<'a, W> Serialization<W, &'a {name}> for Serializer<W> where W: TokenWriter {{
-    fn serialize(&mut self, value: &'a {name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
+impl<W> Serialization<W, {name}> for Serializer<W> where W: TokenWriter {{
+    fn serialize(&mut self, value: &{name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing string enum {name}\");
         let str = match *value {{
 {variants}
@@ -641,8 +641,8 @@ impl ToJSON for {name} {{
                     );
 
                     let to_writer = format!("
-impl<'a, W> Serialization<W, &'a Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
-    fn serialize(&mut self, value: &'a Option<{rust_name}>, path: &mut IOPath) -> Result<(), TokenWriterError> {{
+impl<W> Serialization<W, Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
+    fn serialize(&mut self, value: &Option<{rust_name}>, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing optional sum {rust_name}\");
         match *value {{
             None => {{
@@ -651,12 +651,12 @@ impl<'a, W> Serialization<W, &'a Option<{rust_name}>> for Serializer<W> where W:
                 self.writer.exit_tagged_tuple_at(&{null_interface}{{}}, &interface_name, &[], path)?;
                 Ok(())
             }}
-            Some(ref sum) => (self as &mut Serialization<W, &'a {rust_name}>).serialize(sum, path)
+            Some(ref sum) => self.serialize(sum, path)
         }}
     }}
 }}
-impl<'a, W> Serialization<W, &'a {rust_name}> for Serializer<W> where W: TokenWriter {{
-    fn serialize(&mut self, value: &'a {rust_name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
+impl<W> Serialization<W, {rust_name}> for Serializer<W> where W: TokenWriter {{
+    fn serialize(&mut self, value: &{rust_name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing sum {rust_name}\");
         match *value {{
 {variants}
@@ -673,7 +673,7 @@ impl<'a, W> Serialization<W, &'a {rust_name}> for Serializer<W> where W: TokenWr
                                 format!(
 "           {name}::{constructor}(ref value) => {{
                 // Path will be updated by the serializer for this tagged tuple.
-                (self as &mut Serialization<W, &'a {constructor}>).serialize(value, path)
+                self.serialize(value, path)
             }}",
                                     name = name,
                                     constructor = case.to_class_cases())
@@ -925,8 +925,8 @@ impl<'a> Walker<'a> for ViewMut{name}<'a> {{
 }}
 
 
-impl<'a, W> Serialization<W, &'a {name}> for Serializer<W> where W: TokenWriter {{
-    fn serialize(&mut self, value: &'a {name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
+impl<W> Serialization<W, {name}> for Serializer<W> where W: TokenWriter {{
+    fn serialize(&mut self, value: &{name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing list {name}\");
         self.writer.enter_list_at(value.len(), path)?;
         for child in value {{
@@ -1163,8 +1163,8 @@ impl<R> Deserialization<R, Option<{rust_name}>> for Deserializer<R> where R: Tok
                         .format("\n")
                     );
                 let to_writer = format!("
-impl<'a, W> Serialization<W, &'a Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
-    fn serialize(&mut self, value: &'a Option<{rust_name}>, path: &mut IOPath) -> Result<(), TokenWriterError> {{
+impl<W> Serialization<W, Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
+    fn serialize(&mut self, value: &Option<{rust_name}>, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing optional tagged tuple {name}\");
         match *value {{
             None => {{
@@ -1173,12 +1173,12 @@ impl<'a, W> Serialization<W, &'a Option<{rust_name}>> for Serializer<W> where W:
                 self.writer.exit_tagged_tuple_at(&{null_interface}{{}}, &interface_name, &[], path)?;
                 Ok(())
             }}
-            Some(ref sum) => (self as &mut Serialization<W, &'a {rust_name}>).serialize(sum, path)
+            Some(ref sum) => self.serialize(sum, path)
         }}
     }}
 }}
-impl<'a, W> Serialization<W, &'a {rust_name}> for Serializer<W> where W: TokenWriter {{
-    fn serialize(&mut self, value: &'a {rust_name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
+impl<W> Serialization<W, {rust_name}> for Serializer<W> where W: TokenWriter {{
+    fn serialize(&mut self, value: &{rust_name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing tagged tuple {name}\");
         let interface_name = InterfaceName::from_str(\"{name}\"); // String is shared
         let field_names = [{field_names}];
@@ -1216,7 +1216,7 @@ impl<'a, W> Serialization<W, &'a {rust_name}> for Serializer<W> where W: TokenWr
             let field_name = FieldName::from_str(\"{field_name}\");
             let path_item = ({index}, field_name.clone()); // String is shared
             path.enter_field(path_item.clone());
-            let result = (self as &mut Serialization<W, &'a _>).serialize(&value.{rust_field_name}, path);
+            let result = self.serialize(&value.{rust_field_name}, path);
             path.exit_field(path_item);
             if let Err(err) = result {{
                 break Err(err); // Break with error

--- a/crates/binjs_generate_library/src/lib.rs
+++ b/crates/binjs_generate_library/src/lib.rs
@@ -260,7 +260,7 @@ impl<R> Deserializer<R> where R: TokenReader {{
     }}
 }}
 
-impl<R> Deserialization<R, {name}> for Deserializer<R> where R: TokenReader {{
+impl<R> Deserialization<{name}> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<{name}, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing variant {name}\");
         self.deserialize_variant_{lowercase_name}(path)
@@ -306,7 +306,7 @@ impl FromJSON for {name} {{
 
                 let to_writer = format!(
                     "
-impl<W> Serialization<W, {name}> for Serializer<W> where W: TokenWriter {{
+impl<W> Serialization<{name}> for Serializer<W> where W: TokenWriter {{
     fn serialize(&mut self, value: &{name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing string enum {name}\");
         let str = match *value {{
@@ -521,7 +521,7 @@ impl Default for {name} {{
                     );
 
                     let from_reader = format!("
-impl<R> Deserialization<R, {name}> for Deserializer<R> where R: TokenReader {{
+impl<R> Deserialization<{name}> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<{name}, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing sum {name}\");
         let (kind, _) = self.reader.enter_tagged_tuple_at(path)?;
@@ -541,7 +541,7 @@ impl<R> Deserialization<R, {name}> for Deserializer<R> where R: TokenReader {{
         result
     }}
 }}
-impl<R> Deserialization<R, Option<{name}>> for Deserializer<R> where R: TokenReader {{
+impl<R> Deserialization<Option<{name}>> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<Option<{name}>, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing optional sum {name}\");
         let (kind, _) = self.reader.enter_tagged_tuple_at(path)?;
@@ -641,7 +641,7 @@ impl ToJSON for {name} {{
                     );
 
                     let to_writer = format!("
-impl<W> Serialization<W, Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
+impl<W> Serialization<Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
     fn serialize(&mut self, value: &Option<{rust_name}>, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing optional sum {rust_name}\");
         match *value {{
@@ -655,7 +655,7 @@ impl<W> Serialization<W, Option<{rust_name}>> for Serializer<W> where W: TokenWr
         }}
     }}
 }}
-impl<W> Serialization<W, {rust_name}> for Serializer<W> where W: TokenWriter {{
+impl<W> Serialization<{rust_name}> for Serializer<W> where W: TokenWriter {{
     fn serialize(&mut self, value: &{rust_name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing sum {rust_name}\");
         match *value {{
@@ -925,7 +925,7 @@ impl<'a> Walker<'a> for ViewMut{name}<'a> {{
 }}
 
 
-impl<W> Serialization<W, {name}> for Serializer<W> where W: TokenWriter {{
+impl<W> Serialization<{name}> for Serializer<W> where W: TokenWriter {{
     fn serialize(&mut self, value: &{name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing list {name}\");
         self.writer.enter_list_at(value.len(), path)?;
@@ -1084,7 +1084,7 @@ impl<R> Deserializer<R> where R: TokenReader {{
     }}
 }}
 
-impl<R> InnerDeserialization<R, {rust_name}> for Deserializer<R> where R: TokenReader {{
+impl<R> InnerDeserialization<{rust_name}> for Deserializer<R> where R: TokenReader {{
     fn deserialize_inner(&mut self, path: &mut IOPath) -> Result<{rust_name}, TokenReaderError> where R: TokenReader {{
         let _ = path; // Deactivate warnings if there are no fields.
         print_file_structure!(self.reader, \"{name} {{{{\");
@@ -1096,13 +1096,13 @@ impl<R> InnerDeserialization<R, {rust_name}> for Deserializer<R> where R: TokenR
     }}
 }}
 
-impl<R> Deserialization<R, {rust_name}> for Deserializer<R> where R: TokenReader {{
+impl<R> Deserialization<{rust_name}> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<{rust_name}, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing tagged tuple {rust_name}\");
         self.deserialize_tuple_{lowercase_name}(path)
     }}
 }}
-impl<R> Deserialization<R, Option<{rust_name}>> for Deserializer<R> where R: TokenReader {{
+impl<R> Deserialization<Option<{rust_name}>> for Deserializer<R> where R: TokenReader {{
     fn deserialize(&mut self, path: &mut IOPath) -> Result<Option<{rust_name}>, TokenReaderError> {{
         debug!(target: \"deserialize_es6\", \"Deserializing optional tuple {rust_name}\");
         let (kind, _) = self.reader.enter_tagged_tuple_at(path)?;
@@ -1163,7 +1163,7 @@ impl<R> Deserialization<R, Option<{rust_name}>> for Deserializer<R> where R: Tok
                         .format("\n")
                     );
                 let to_writer = format!("
-impl<W> Serialization<W, Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
+impl<W> Serialization<Option<{rust_name}>> for Serializer<W> where W: TokenWriter {{
     fn serialize(&mut self, value: &Option<{rust_name}>, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing optional tagged tuple {name}\");
         match *value {{
@@ -1177,7 +1177,7 @@ impl<W> Serialization<W, Option<{rust_name}>> for Serializer<W> where W: TokenWr
         }}
     }}
 }}
-impl<W> Serialization<W, {rust_name}> for Serializer<W> where W: TokenWriter {{
+impl<W> Serialization<{rust_name}> for Serializer<W> where W: TokenWriter {{
     fn serialize(&mut self, value: &{rust_name}, path: &mut IOPath) -> Result<(), TokenWriterError> {{
         debug!(target: \"serialize_es6\", \"Serializing tagged tuple {name}\");
         let interface_name = InterfaceName::from_str(\"{name}\"); // String is shared

--- a/crates/binjs_io/src/io/mod.rs
+++ b/crates/binjs_io/src/io/mod.rs
@@ -354,12 +354,12 @@ pub trait TokenWriter {
 pub trait Serialization<W, T>
 where
     W: TokenWriter,
-    T: Sized,
+    T: ?Sized,
 {
     /// Serialize a piece of data.
     ///
     /// `path` indicates the path from the root of the AST.
-    fn serialize(&mut self, data: T, path: &mut Path) -> Result<(), TokenWriterError>;
+    fn serialize(&mut self, data: &T, path: &mut Path) -> Result<(), TokenWriterError>;
 }
 pub trait TokenSerializer<W>
 where
@@ -370,7 +370,7 @@ where
 pub trait RootedTokenSerializer<W, T>: Serialization<W, T> + TokenSerializer<W>
 where
     W: TokenWriter,
-    T: Sized,
+    T: ?Sized,
 {
 }
 pub trait TokenSerializerFamily<T> {

--- a/crates/binjs_io/src/io/mod.rs
+++ b/crates/binjs_io/src/io/mod.rs
@@ -351,9 +351,8 @@ pub trait TokenWriter {
     }
 }
 
-pub trait Serialization<W, T>
+pub trait Serialization<T>
 where
-    W: TokenWriter,
     T: ?Sized,
 {
     /// Serialize a piece of data.
@@ -367,7 +366,7 @@ where
 {
     fn done(self) -> Result<W::Data, TokenWriterError>;
 }
-pub trait RootedTokenSerializer<W, T>: Serialization<W, T> + TokenSerializer<W>
+pub trait RootedTokenSerializer<W, T>: Serialization<T> + TokenSerializer<W>
 where
     W: TokenWriter,
     T: ?Sized,
@@ -379,16 +378,14 @@ pub trait TokenSerializerFamily<T> {
         W: TokenWriter;
 }
 
-pub trait Deserialization<R, T>
+pub trait Deserialization<T>
 where
-    R: TokenReader,
     T: Sized,
 {
     fn deserialize(&mut self, &mut Path) -> Result<T, TokenReaderError>;
 }
-pub trait InnerDeserialization<R, T>
+pub trait InnerDeserialization<T>
 where
-    R: TokenReader,
     T: Sized,
 {
     fn deserialize_inner(&mut self, &mut Path) -> Result<T, TokenReaderError>;

--- a/src/bin/generate_dictionary.rs
+++ b/src/bin/generate_dictionary.rs
@@ -8,7 +8,7 @@ extern crate env_logger;
 
 use binjs::generic::FromJSON;
 use binjs::io::entropy::dictionary::DictionaryBuilder;
-use binjs::io::{Path as IOPath, TokenSerializer};
+use binjs::io::{Path as IOPath, Serialization, TokenSerializer};
 use binjs::source::{Shift, SourceParser};
 use binjs::specialized::es6::ast::Walker;
 

--- a/tests/test_dictionary_builder.rs
+++ b/tests/test_dictionary_builder.rs
@@ -5,7 +5,7 @@ use binjs::generic::{FromJSON, IdentifierName, InterfaceName, Offset, PropertyKe
 use binjs::io::entropy;
 use binjs::io::entropy::dictionary::{DictionaryBuilder, FilesContaining, LinearTable};
 use binjs::io::entropy::rw::TableRefStreamState;
-use binjs::io::{Deserialization, TokenSerializer};
+use binjs::io::{Deserialization, Serialization, TokenSerializer};
 use binjs::source::{Shift, SourceParser};
 use binjs::specialized::es6::ast::{Script, Visitor, WalkPath, Walker};
 use binjs::specialized::es6::io::IOPath;

--- a/tests/test_paths.rs
+++ b/tests/test_paths.rs
@@ -10,7 +10,7 @@ extern crate binjs;
 use binjs::generic::{
     FieldName, FromJSON, IdentifierName, InterfaceName, Node, PropertyKey, SharedString,
 };
-use binjs::io::{TokenWriter, TokenWriterError};
+use binjs::io::{Serialization, TokenWriter, TokenWriterError};
 use binjs::source::{Shift, SourceParser};
 use binjs::specialized::es6::io::IOPath;
 


### PR DESCRIPTION
In all cases `Serialization` already needs only a borrowed value, similarly to `serde::Serialize`, or an owned value of a primitive, which is easy and cheap to get from a borrow.

Hence, the definition can get simpler by always assuming a borrowed value of any type instead of requiring implementations with an explicit lifetime param.