### PR TITLE
Resolve #304 - Reduce sparsity of shared indices

### DIFF
--- a/crates/binjs_io/src/entropy/read/content_decoders.rs
+++ b/crates/binjs_io/src/entropy/read/content_decoders.rs
@@ -62,11 +62,12 @@ where
             }
             None => 0,
         };
+        let index_stream_state = TableRefStreamState::new(window_len, &indexed_dictionary);
         Ok(Self {
             indexed_dictionary,
             stream: maybe_stream,
             name,
-            index_stream_state: TableRefStreamState::new(window_len),
+            index_stream_state,
         })
     }
 }
@@ -98,10 +99,7 @@ where
                     Ok(result) => result,
                     Err(err) => return Some(Err(TokenReaderError::ReadError(err))),
                 };
-                let index = match self
-                    .index_stream_state
-                    .from_u32(as_u32, &self.indexed_dictionary)
-                {
+                let index = match self.index_stream_state.from_u32(as_u32) {
                     Some(index) => index,
                     None => {
                         return Some(Err(TokenReaderError::BadDictionaryIndex {
@@ -110,7 +108,6 @@ where
                         }));
                     }
                 };
-                debug!(target: "read", "DictionaryStreamDecoder::next {} index: {:?}", self.name, index);
                 let result = self.indexed_dictionary.at_index(&index).unwrap(); // We have checked just above that the `index` is correct.
                 Some(Ok(result.clone()))
             }

--- a/crates/binjs_io/src/entropy/rw.rs
+++ b/crates/binjs_io/src/entropy/rw.rs
@@ -1,6 +1,8 @@
 //! Constants and data structures shared between entropy read and entropy write.
 
-use entropy::dictionary::{LinearTable, TableRef};
+use entropy::dictionary::{Fetch, LinearTable, TableRef};
+
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use smallvec::SmallVec;
@@ -159,11 +161,69 @@ pub type NameData = SmallVec<[u8; NAME_MAX_LEN]>;
 /// Used to (de)serialize `TableRef`, as the encoding of an `TableRef`
 /// may depend on that of previous values.
 ///
-/// `TableRef` values are represented as follows:
-/// - a value `0` represents an `TableRef::Prelude` with index 1 + the latest `TableRef::Prelude` value we have encoded/decoded;
-/// - a value `v` in `[1, window len]` represents a repeat of a previous value: 1 it the latest value, 2 the second latest, etc.
-/// - a value `v` in `[window len + 1, window len + length of the shared dictionary]` represent `TableRef::Shared` with index `v - window len - 1`;
-/// - a value `v > window len + length of the shared dictionary` represents `TableRef::Prelude` with index `v - window len - length of shared dictionary - 1`.
+/// # Format
+///
+/// u32 representation: `TableRef` interpretation
+///
+/// - Next in Prelude
+///    - `0`: `TableRef::Prelude(prelude_latest + 1)`
+///           where `prelude_latest` is the latest prelude value encountered
+///           so far or -1 if no prelude value has been encountered yet
+///
+/// - Recall Window Range [1, window_len] where `window_len` is the length
+///           of the window, specified when creating the `TableRefStreamState`
+///    - `1`: Latest value
+///    - `2`: Second latest value
+///    - ...
+///    - `window_len`: ...
+///
+/// - Reference into Prelude Range: [window_len + 1, window_len + prelude_len]
+///           where `prelude_len` is the number of elements in the Prelude.
+///    - `window_len + 1`: `TableRef::Prelude(0)`
+///    - `window_len + 2`: `TableRef::Prelude(1)`
+///    - ...
+///
+///  - Imported Reference into Shared Range: [window_len + prelude_len + 1,
+///            window_len + import_len], where `import_len` is the number of
+///            **distinct** `TableRef::Shared` references encountere **so far**
+///            in the stream.
+///    - `window_len + prelude_len + 1`: `TableRef::Shared(s1)`
+///            where `TableRef::Shared(s1)` was the first `TableRef::Shared`
+///            reference encountered in the stream
+///    - `window_len + prelude_len + 2`: `TableRef::Shared(s2)`
+///            where `TableRef::Shared(s2)` was the first `TableRef::Shared`
+///            reference encountered in the stream and distinct from `s1`
+///    - `window_len + prelude_len + 3`: `TableRef::Shared(s3)`
+///            where `TableRef::Shared(s1)` was the first `TableRef::Shared`
+///            reference encountered in the stream and distinct from `s1`, `s2`,
+///            ...
+///    - ...
+///
+/// - First-time Reference into Shared Range: [window_len + prelude_len + import_len + 1,
+///             ...[
+///    - `window_len + prelude_len + import_len + 1`: `TableRef::Shared(0)`
+///    - `window_len + prelude_len + import_len + 2`: `TableRef::Shared(2)`
+///    - ...
+///
+/// # Design notes
+///
+/// The main goals of this format are to:
+///
+/// - support both stream reading;
+/// - expose wherever possible patterns that a stream compressor (e.g. brotli) can
+///    use to efficiently compress the stream.
+///
+/// Experiments show that the use of `0` and, for some streams, the Recall Window Range,
+/// expose such useful patterns.
+///
+/// Experiments show that the dual Imported Shared References/First-time Shared
+/// References mechanism considerably decrease the sparsity of references into the
+/// shared dictionary. Where raw references into the shared dictionary are typically
+/// represented by a 3 bytes long varnum, consisting in unpredictable bytes, this
+/// mechanism tends to reduce them to varnums that may be represented with either 1
+/// byte or 2 bytes with a small (hence easy to predict) first byte. In turn, this
+/// exposes patterns that the stream compressor may use efficiently.
+#[derive(Debug)]
 pub struct TableRefStreamState<T> {
     /// The latest `TableRef::Prelude` value.
     ///
@@ -191,6 +251,35 @@ pub struct TableRefStreamState<T> {
     /// integers to reserve to represent backreferences to values encountered
     /// recently.
     window_max_len: usize,
+
+    /// A mapping from shared references (`TableRef::Shared(s)`) to the number
+    /// of shared references in this stream encountered before `s`. In other
+    /// words, the the first entry added (by chronological order) maps to `0`,
+    /// the second maps to `1`, etc. Used to ensure that `TableRef::Shared` references
+    /// fit in successive values, and are generally small enough to be represented by
+    /// a varnum of 1 or 2 bytes, instead of being all over the place.
+    ///
+    /// If the `TableRefStreamState` is used for decoding, this map is empty.
+    ///
+    /// Invariant: Keys are always `TableRef::Shared`.
+    /// Invariant: Values are contiguous, starting with 0.
+    shared_reference_to_write_order: HashMap<TableRef, u32>,
+
+    /// A mapping from read order to `TableRef::Shared` instances, i.e.
+    /// the first entry read (by chronological order) is at position `0`,
+    /// the second at position `1`, etc. Used to ensure that `TableRef::Shared`
+    /// references are generally small enough to fit in small varnums.
+    ///
+    /// If the `TableRefStreamState` is used for encoding, this vector is empty.
+    ///
+    /// Invariant: Values are always `TableRef::Shared`.
+    shared_reference_by_read_order: Vec<TableRef>,
+
+    /// The number of entries in the prelude.
+    prelude_len: usize,
+
+    /// The number of entries in the shared dictionary.
+    shared_len: usize,
 }
 impl<T> TableRefStreamState<T>
 where
@@ -200,12 +289,16 @@ where
     ///
     /// `window_max_len` represents the number of integers to reserve to
     /// represent backreferences to values encountered recently.
-    pub fn new(window_max_len: usize) -> Self {
+    pub fn new(window_max_len: usize, table: &LinearTable<T>) -> Self {
         TableRefStreamState {
             latest_in_prelude: None,
             phantom: PhantomData,
             window_max_len,
             window: Vec::with_capacity(window_max_len),
+            shared_reference_to_write_order: HashMap::new(),
+            shared_reference_by_read_order: vec![],
+            shared_len: table.shared_len(),
+            prelude_len: table.prelude_len(),
         }
     }
 
@@ -218,13 +311,8 @@ where
         }
     }
 
-    /// Decode an `TableRef` from a `u32`.
-    pub fn from_u32(&mut self, value: u32, table: &LinearTable<T>) -> Option<TableRef> {
-        debug!(target: "rw", "TableRefStreamState::from_u32 {} with window_len {}, shared_len {}, total len {}",
-            value,
-            self.window_max_len,
-            table.shared_len(),
-            table.len());
+    /// Decode a `TableRef` from a `u32`.
+    pub fn from_u32(&mut self, value: u32) -> Option<TableRef> {
         let index = loop {
             // Fake loop, used simply to be able to `break` out.
             if value == 0 {
@@ -232,27 +320,46 @@ where
                 let next_in_prelude = self.next_in_prelude();
                 break TableRef::Prelude(next_in_prelude as usize);
             }
+
             // Renormalize from 0.
             let value = value - 1;
-            debug!(target: "rw", "TableRefStreamState::from_u32, value is not 0, renormalizing to {}",
+            debug!(target: "rw", "TableRefStreamState::from_u32, value is not 0, renormalizing to {}, checking if it's in the floating window",
                 value);
             if (value as usize) < self.window_max_len {
                 // this is a hit in the floating window.
                 break *self.window.get(value as usize)?;
             }
 
-            // Renormalize from 0 again.
+            // Renormalize from 0.
             let value = value - self.window_max_len as u32;
-            debug!(target: "rw", "TableRefStreamState::from_u32, value is not in window, renormalizing to {}",
-                value);
-            if (value as usize) < table.shared_len() {
-                break TableRef::Shared(value as usize);
-            }
-
-            // Values beyond `table.shared_len()` represent prelude indices.
-            if (value as usize) < table.len() {
+            debug!(target: "rw", "TableRefStreamState::from_u32, renormalizing to {}, checking if it's in the prelude (prelude len is {})",
+                value,
+                self.prelude_len);
+            if (value as usize) < self.prelude_len {
                 break TableRef::Prelude(value as usize);
             }
+
+            // Renormalize from 0.
+            let value = value - self.prelude_len as u32;
+            debug!(target: "rw", "TableRefStreamState::from_u32, renormalizing to {}, checking if it's an imported shared reference",
+                value);
+            if (value as usize) < self.shared_reference_by_read_order.len() {
+                // this is a shared reference that we have already encountered
+                break self.shared_reference_by_read_order[value as usize];
+            }
+
+            // Renormalize from 0.
+            let value = value - self.shared_reference_by_read_order.len() as u32;
+            debug!(target: "rw", "TableRefStreamState::from_u32, renormalizing to {}, checking if it's a fresh shared reference",
+                value);
+            if (value as usize) < self.shared_len {
+                let result = TableRef::Shared(value as usize);
+                self.shared_reference_by_read_order.push(result);
+                break result;
+            }
+
+            debug!(target: "rw", "TableRefStreamState::from_u32, oh, we didn't find any result");
+
             return None;
         };
         // Update caches (latest in prelude, position in window).
@@ -297,21 +404,71 @@ where
         None
     }
 
+    /// Mark a `TableRef::Shared` as encountered if necessary, return the information
+    /// necessary to encode it as `u32`.
+    ///
+    /// If this is the first instance of `value` to be encoded, return `Fetch::Miss(index)`,
+    /// where `index` is in `[import len, import len + shared len[` and `import len` is
+    /// the number of distinct instances of `TableRef::Shared` encountered
+    /// so far. Also, record `number of distinct instances of
+    /// `TableRef::Shared` encountered so far as the future index for `value`.
+    ///
+    /// Otherwise, return `Fetch::Hit(index)`, where `index`  is the index recorded above,
+    /// in `[0, total import len[`, and `total import len` is the total number of distinct
+    /// instances of `TableRef::Shared` encountered in the file.
+    ///
+    /// # Failures
+    ///
+    /// Panics if `value` is not a `TableRef::Shared`.
+    fn update_shared_reference_to_write_order(&mut self, value: TableRef) -> Fetch<u32> {
+        use std::collections::hash_map::Entry;
+        let len = self.shared_reference_to_write_order.len() as u32;
+        debug_assert!(value.as_shared().is_some());
+        debug!(target: "rw", "TableRefStreamState::update_shared_reference_to_write_order adding {:?} to {:?}",
+            value,
+            self.shared_reference_to_write_order);
+        match self.shared_reference_to_write_order.entry(value) {
+            Entry::Occupied(o) => Fetch::Hit(*o.get()),
+            Entry::Vacant(v) => {
+                // Insert a new value.
+                v.insert(len);
+                // Return the position in the .
+                Fetch::Miss(len + value.as_shared().unwrap() as u32)
+            }
+        }
+    }
+
     /// Encode an `TableRef` into a `u32`.
     ///
     /// This method does *not* perform any kind of sanity check on the `TableRef`.
     pub fn into_u32(&mut self, value: TableRef) -> u32 {
+        debug!(target: "rw", "TableRefStreamState::into_u32, encoding {:?}", value);
         let maybe_position_in_window = self.update_position_in_window(value);
 
         match value {
-            TableRef::Shared(i) => {
-                match maybe_position_in_window {
-                    // If we repeat a recent value, emit its position.
+            TableRef::Shared(_) => {
+                debug!(target: "rw", "TableRefStreamState::into_u32, it's a shared value");
+                if let Some(pos) = maybe_position_in_window {
+                    debug!(target: "rw", "TableRefStreamState::into_u32, it's a repeat {}", pos);
+                    // If we repeat a recent value, emit its position in the window.
                     // Use interval [1, self.window_max_len].
-                    Some(pos) => (pos + 1) as u32,
-                    // Otherwise, emit a direct reference to the shared dictionary.
-                    // Use interval ]self.window_max_len, self.window_max_len + self.shared_len]
-                    None => (i + self.window_max_len + 1) as u32,
+                    return pos as u32 + 1;
+                }
+                debug!(target: "rw", "TableRefStreamState::into_u32, it's not a repeat - prelude len is {}", self.prelude_len);
+                match self.update_shared_reference_to_write_order(value) {
+                    Fetch::Hit(pos) => {
+                        debug!(target: "rw", "TableRefStreamState::into_u32, it's already imported at {}", pos);
+                        // If we repeat a shared reference that we have seen at least once,
+                        // emit its position in the table of imported shared references.
+                        // Use interval ]self.window_max_len + prelude_len, self.window_max_len + prelude_len + self.imported_len].
+                        return self.window_max_len as u32 + self.prelude_len as u32 + pos + 1;
+                    }
+                    Fetch::Miss(pos) => {
+                        debug!(target: "rw", "TableRefStreamState::into_u32, we need to import it from {}", pos);
+                        // Otherwise, emit the position in the shared dictionary.
+                        // Use interval ]self.window_max_len + prelude_len + self.imported_len, ...].
+                        return self.window_max_len as u32 + self.prelude_len as u32 + pos + 1;
+                    }
                 }
             }
             // References to the prelude dictionary may be 0 (for next) or shifted by 1.

--- a/crates/binjs_io/src/io/mod.rs
+++ b/crates/binjs_io/src/io/mod.rs
@@ -19,6 +19,7 @@ mod deprecated;
 pub use self::deprecated::{TokenWriterTreeAdapter, TokenWriterWithTree};
 
 /// Utilities to collect statistics about the data written.
+#[macro_use]
 pub mod statistics;
 
 /// An API for printing the binary representation and its structural


### PR DESCRIPTION
This applies the transformation presented in #304 to reduce the sparsity of shared indices. It improves compression by ~4.5%.