### PR TITLE
Make it easier to share elements of a Dictionary.

### DIFF
--- a/crates/binjs_io/Cargo.toml
+++ b/crates/binjs_io/Cargo.toml
@@ -17,7 +17,7 @@ lzw = "^0.10"
 log = "^0.4"
 rand = "^0.6"
 range-encoding = "^0.2"
-serde = { version = "^1.0", features = ["derive"] }
+serde = { version = "^1.0", features = ["derive", "rc"] }
 smallvec = "^0.6"
 vec_map = "^0.8"
 xml-rs = "^0.8"

--- a/crates/binjs_io/src/entropy/probabilities.rs
+++ b/crates/binjs_io/src/entropy/probabilities.rs
@@ -22,7 +22,7 @@ pub struct SymbolInfo {
 /// or a set of probability distributions.
 pub trait InstancesToProbabilities {
     type AsProbabilities;
-    fn instances_to_probabilities(self, description: &str) -> Self::AsProbabilities;
+    fn instances_to_probabilities(&self, description: &str) -> Self::AsProbabilities;
 }
 
 /// A structure that may be converted into statistical information.

--- a/crates/binjs_io/src/entropy/read/mod.rs
+++ b/crates/binjs_io/src/entropy/read/mod.rs
@@ -314,16 +314,12 @@ macro_rules! main_stream {
         use std::ops::DerefMut;
         let path = $path.borrow();
 
+        let table = $me.options.probability_tables.$table();
         let index = {
             // 1. Get the frequency information for this path.
-            let frequencies = $me
-                .options
-                .probability_tables
-                .$table()
-                .frequencies_at(path)
-                .ok_or_else(|| {
-                    TokenReaderError::NotInDictionary(format!("{} at {:?}", $description, $path))
-                })?;
+            let frequencies = table.frequencies_at(path).ok_or_else(|| {
+                TokenReaderError::NotInDictionary(format!("{} at {:?}", $description, $path))
+            })?;
             let mut borrow = frequencies.borrow_mut();
 
             // 2. Let bit-level I/O determine the symbol index stored.
@@ -335,10 +331,7 @@ macro_rules! main_stream {
         };
 
         // 3. Deduce the value we have just read.
-        let value = $me
-            .options
-            .probability_tables
-            .$table()
+        let value = table
             .value_by_symbol_index(path, SymbolIndex::new(index as usize))
             .ok_or_else(|| {
                 TokenReaderError::NotInDictionary(format!("{} [{}]", stringify!($ident), index))


### PR DESCRIPTION
We put all the fields of `Dictionary` behind a `Rc<RefCell<>>`. This makes
a call to `Dictionary::clone` cheap, but more importantly, once we start
using dictionaries for sublanguages, this lets us share the elements
that need to be shared between the sublanguages.