### PR TITLE
Use std::fs::{write, read_to_string} when possible

### DIFF
--- a/crates/binjs_es6/build.rs
+++ b/crates/binjs_es6/build.rs
@@ -6,8 +6,7 @@ use binjs_meta::import::Importer;
 use binjs_meta::spec::SpecOptions;
 
 use std::env;
-use std::fs::*;
-use std::io::*;
+use std::fs;
 
 /// The webidl source files.
 ///
@@ -25,7 +24,7 @@ fn main() {
     let sources: Vec<_> = PATH_SOURCES
         .iter()
         .map(|path| {
-            read_to_string(path)
+            fs::read_to_string(path)
                 .unwrap_or_else(|e| panic!("Could not open grammar file {}: {}", path, e))
         })
         .collect();
@@ -51,10 +50,7 @@ fn main() {
     // Export strongly-typed source.
     let dest_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");
     let dest_name = format!("{}/ast.rs", dest_dir);
-    let mut dest =
-        File::create(dest_name).expect("Could not create rust strongly-typed source output");
-    dest.write_all(code.typed.as_bytes())
-        .expect("Could not write rust strongly-typed source output");
+    fs::write(dest_name, code.typed).expect("Could not write rust strongly-typed source output");
 
     println!("...done");
 }

--- a/crates/binjs_generate_library/examples/generate_library.rs
+++ b/crates/binjs_generate_library/examples/generate_library.rs
@@ -7,8 +7,7 @@ use binjs_generate_library::*;
 use binjs_meta::import::Importer;
 use binjs_meta::spec::SpecOptions;
 
-use std::fs::*;
-use std::io::*;
+use std::fs;
 
 use clap::*;
 
@@ -33,10 +32,7 @@ fn main() {
         .expect("Expected INPUT.webidl");
     let dest_path = matches.value_of("OUTPUT").expect("Expected OUTPUT");
 
-    let mut file = File::open(source_path).expect("Could not open source");
-    let mut source = String::new();
-    file.read_to_string(&mut source)
-        .expect("Could not read source");
+    let source = fs::read_to_string(source_path).expect("Could not read source");
 
     println!("...importing webidl");
     let mut builder =
@@ -55,16 +51,11 @@ fn main() {
 
     let dest_name = format!("{}-generic.rs", dest_path);
     println!("...exporting generic code to {}", dest_name);
-    let mut dest = File::create(dest_name).expect("Could not create rust generic source output");
-    dest.write_all(code.generic.as_bytes())
-        .expect("Could not write rust generic source output");
+    fs::write(dest_name, code.generic).expect("Could not write rust generic source output");
 
     let dest_name = format!("{}-strong.rs", dest_path);
     println!("...exporting strongly-typed code to {}", dest_name);
-    let mut dest =
-        File::create(dest_name).expect("Could not create rust strongly-typed source output");
-    dest.write_all(code.typed.as_bytes())
-        .expect("Could not write rust strongly-typed source output");
+    fs::write(dest_name, code.typed).expect("Could not write rust strongly-typed source output");
 
     println!("...done");
 }

--- a/crates/binjs_generic/build.rs
+++ b/crates/binjs_generic/build.rs
@@ -6,8 +6,7 @@ use binjs_meta::import::Importer;
 use binjs_meta::spec::SpecOptions;
 
 use std::env;
-use std::fs::*;
-use std::io::*;
+use std::fs;
 
 /// The webidl source files.
 ///
@@ -25,7 +24,7 @@ fn main() {
     let sources: Vec<_> = PATH_SOURCES
         .iter()
         .map(|path| {
-            read_to_string(path)
+            fs::read_to_string(path)
                 .unwrap_or_else(|e| panic!("Could not open grammar file {}: {}", path, e))
         })
         .collect();
@@ -47,9 +46,7 @@ fn main() {
     // Export generic source.
     let dest_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");
     let dest_name = format!("{}/es6.rs", dest_dir);
-    let mut dest = File::create(dest_name).expect("Could not create rust generic source output");
-    dest.write_all(code.generic.as_bytes())
-        .expect("Could not write rust generic source output");
+    fs::write(dest_name, code.generic).expect("Could not write rust generic source output");
 
     println!("...done");
 }

--- a/crates/binjs_io/src/entropy/write/lazy_stream.rs
+++ b/crates/binjs_io/src/entropy/write/lazy_stream.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsString;
+use std::fs;
 use std::io::Write;
 
 /// Highest Brotli compression level.
@@ -67,12 +68,11 @@ impl LazyStream {
         if let Some(mut path) = self.dump_path.take() {
             {
                 let dir = path.parent().unwrap();
-                std::fs::DirBuilder::new().recursive(true).create(dir)?;
+                fs::DirBuilder::new().recursive(true).create(dir)?;
             }
 
             // Prepare the file for raw dumping.
-            let mut raw = std::fs::File::create(&path)?;
-            raw.write_all(&self.buffer)?;
+            fs::write(&path, &self.buffer)?;
 
             // Prepare the file for brotli-compressed dumping.
             // Create a double-extension ".foo.bro".
@@ -85,8 +85,7 @@ impl LazyStream {
                 }
             };
             path.set_extension(extension);
-            let mut brotli = std::fs::File::create(path)?;
-            brotli.write_all(&brotli_compressed)?;
+            fs::write(path, &brotli_compressed)?;
         }
 
         Ok(Some(brotli_compressed))

--- a/crates/binjs_io/src/entropy/write/mod.rs
+++ b/crates/binjs_io/src/entropy/write/mod.rs
@@ -15,6 +15,7 @@ use binjs_shared::{
     FieldName, IdentifierName, InterfaceName, Node, PropertyKey, SharedString, F64,
 };
 
+use std::fs;
 use std::io::Write;
 
 #[allow(unused_imports)] // We keep enabling/disabling this.
@@ -435,15 +436,12 @@ impl TokenWriter for Encoder {
         let entropy = self.writer.done().map_err(TokenWriterError::WriteError)?;
 
         if let Some(path) = self.dump_path {
-            std::fs::DirBuilder::new()
+            fs::DirBuilder::new()
                 .recursive(true)
                 .create(path.parent().unwrap())
                 .map_err(TokenWriterError::WriteError)?;
 
-            let mut file = std::fs::File::create(path).map_err(TokenWriterError::WriteError)?;
-            file.write_all(&entropy)
-                .map_err(TokenWriterError::WriteError)?;
-            file.flush().map_err(TokenWriterError::WriteError)?;
+            fs::write(path, &entropy).map_err(TokenWriterError::WriteError)?;
         }
 
         data.write_all(&entropy)

--- a/crates/binjs_io/src/simple.rs
+++ b/crates/binjs_io/src/simple.rs
@@ -560,15 +560,19 @@ fn test_simple_io() {
     use binjs_shared::ast::Path;
     use binjs_shared::{FieldName, InterfaceName, SharedString};
     use io::TokenWriterWithTree;
-    use std::fs::*;
+    use std::fs;
 
-    use std::io::{Cursor, Write};
+    use std::io::Cursor;
 
     let path = Path::new();
 
     let dir = tempdir::TempDir::new("test_multipart_io").unwrap();
     let root = dir.path();
-    let new_file = |prefix: &str| File::create(root.join(prefix));
+    let write_file = |prefix: &str, contents: &[u8]| {
+        let path = root.join(prefix);
+        fs::write(&path, contents)
+            .unwrap_or_else(|e| panic!("Could not write file {:?}: {:?}", path, e));
+    };
 
     eprintln!("Testing string I/O");
 
@@ -579,10 +583,7 @@ fn test_simple_io() {
             .expect("Writing simple string");
 
         let data = writer.data().unwrap();
-        new_file("test-simple-string")
-            .unwrap()
-            .write_all(data)
-            .unwrap();
+        write_file("test-simple-string", data);
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
         let simple_string = reader
@@ -600,10 +601,7 @@ fn test_simple_io() {
             .expect("Writing string with escapes");
 
         let result = writer.data().unwrap();
-        new_file("test-string-with-escapes")
-            .unwrap()
-            .write_all(result)
-            .unwrap();
+        write_file("test-string-with-escapes", result);
 
         let mut reader = TreeTokenReader::new(Cursor::new(result));
         let escapes_string = reader
@@ -622,10 +620,7 @@ fn test_simple_io() {
             .expect("Writing empty untagged tuple");
 
         let data = writer.data().unwrap();
-        new_file("test-empty-untagged-tuple")
-            .unwrap()
-            .write_all(data)
-            .unwrap();
+        write_file("test-empty-untagged-tuple", data);
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
         reader
@@ -646,10 +641,7 @@ fn test_simple_io() {
             .expect("Writing trivial untagged tuple");
 
         let data = writer.data().unwrap();
-        new_file("test-trivial-untagged-tuple")
-            .unwrap()
-            .write_all(data)
-            .unwrap();
+        write_file("test-trivial-untagged-tuple", data);
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
         reader
@@ -688,10 +680,7 @@ fn test_simple_io() {
             .expect("Writing trivial tagged tuple");
 
         let data = writer.data().unwrap();
-        new_file("test-simple-tagged-tuple")
-            .unwrap()
-            .write_all(data)
-            .unwrap();
+        write_file("test-simple-tagged-tuple", data);
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
         let (name, fields) = reader
@@ -726,10 +715,7 @@ fn test_simple_io() {
         writer.list(vec![]).expect("Writing empty list");
 
         let data = writer.data().unwrap();
-        new_file("test-empty-list")
-            .unwrap()
-            .write_all(data)
-            .unwrap();
+        write_file("test-empty-list", data);
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
         let len = reader.enter_list_at(&path).expect("Reading empty list");
@@ -749,10 +735,7 @@ fn test_simple_io() {
             .expect("Writing trivial list");
 
         let data = writer.data().unwrap();
-        new_file("test-trivial-list")
-            .unwrap()
-            .write_all(data)
-            .unwrap();
+        write_file("test-trivial-list", data);
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
         let len = reader.enter_list_at(&path).expect("Reading trivial list");
@@ -784,10 +767,7 @@ fn test_simple_io() {
         writer.list(vec![list]).expect("Writing outer list");
 
         let data = writer.data().unwrap();
-        new_file("test-nested-lists")
-            .unwrap()
-            .write_all(data)
-            .unwrap();
+        write_file("test-nested-lists", data);
 
         let mut reader = TreeTokenReader::new(Cursor::new(data));
         let len = reader.enter_list_at(&path).expect("Reading outer list");

--- a/examples/compare_compression.rs
+++ b/examples/compare_compression.rs
@@ -17,7 +17,7 @@ use clap::*;
 use itertools::Itertools;
 
 use std::collections::HashMap;
-use std::io::Write;
+use std::fs;
 use std::process::Command;
 
 #[derive(Add, AddAssign, Clone, Default)]
@@ -140,13 +140,7 @@ fn main() {
                 .encode(None, &mut format, &ast)
                 .expect("Could not encode");
 
-            {
-                let mut binjs_encoded = std::fs::File::create(&dest_path_binjs)
-                    .expect("Could not create binjs-encoded file");
-                binjs_encoded
-                    .write_all((*data).as_ref())
-                    .expect("Could not write binjs-encoded file");
-            }
+            fs::write(&dest_path_binjs, data.as_ref()).expect("Could not write binjs-encoded file");
 
             let from_binjs = get_compressed_sizes(&std::path::Path::new(dest_path_binjs));
 

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -17,7 +17,7 @@ use binjs::specialized::es6::ast::Walker;
 use binjs::specialized::es6::io::Encoder;
 
 use clap::*;
-use std::io::Write;
+use std::fs;
 
 fn main() {
     env_logger::init();
@@ -120,26 +120,15 @@ Note that this tool does not attempt to make sure that the files are entirely co
             i += 1;
 
             println!("Generated sample {}/{}", i, number);
-            {
-                let mut source_file = std::fs::File::create(format!("{}-{}.js", prefix, i))
-                    .expect("Could not create js file");
-                source_file
-                    .write_all(source.as_bytes())
-                    .expect("Could not write js file");
-            }
+            fs::write(format!("{}-{}.js", prefix, i), source).expect("Could not write js file");
 
             let encoder = Encoder::new();
             let encoded = encoder
                 .encode(None, &mut format, &ast)
                 .expect("Could not encode AST");
 
-            {
-                let mut encoded_file = std::fs::File::create(format!("{}-{}.binjs", prefix, i))
-                    .expect("Could not create binjs file");
-                encoded_file
-                    .write_all(encoded.as_ref().as_ref())
-                    .expect("Could not write binjs file");
-            }
+            fs::write(format!("{}-{}.binjs", prefix, i), encoded.as_ref())
+                .expect("Could not write binjs file");
         } else {
             println!("...could not pretty print this sample");
             continue;

--- a/src/bin/decode.rs
+++ b/src/bin/decode.rs
@@ -8,7 +8,7 @@ use binjs::generic::ToJSON;
 use binjs::source::Shift;
 use binjs::specialized::es6::io::Decoder;
 
-use std::fs::*;
+use std::fs::{self, File};
 use std::io::*;
 
 use clap::*;
@@ -114,9 +114,7 @@ fn main() {
     progress!(quiet, "Writing.");
     match options.dest_path {
         Some(path) => {
-            let mut dest = File::create(path).expect("Could not create destination file");
-            dest.write(source.as_bytes())
-                .expect("Could not write destination file");
+            fs::write(path, source).expect("Could not write destination file");
         }
         None => {
             stdout()

--- a/src/bin/dump.rs
+++ b/src/bin/dump.rs
@@ -7,7 +7,7 @@ extern crate env_logger;
 use binjs::io::Deserialization;
 use binjs::io::FileStructurePrinter;
 
-use std::fs::*;
+use std::fs::File;
 use std::io::*;
 
 use clap::*;

--- a/src/bin/generate_dictionary.rs
+++ b/src/bin/generate_dictionary.rs
@@ -12,7 +12,7 @@ use binjs::io::{Path as IOPath, Serialization, TokenSerializer};
 use binjs::source::{Shift, SourceParser};
 use binjs::specialized::es6::ast::Walker;
 
-use std::fs::*;
+use std::fs::{self, File};
 use std::path::Path;
 use std::thread;
 
@@ -40,13 +40,13 @@ fn handle_path<'a>(
     sub_dir: &Path,
 ) {
     progress!(options.quiet, "Treating {:?} ({:?})", source_path, sub_dir);
-    let is_dir = std::fs::metadata(source_path).unwrap().is_dir();
+    let is_dir = fs::metadata(source_path).unwrap().is_dir();
     if is_dir {
         let file_name = source_path
             .file_name()
             .unwrap_or_else(|| panic!("Invalid source path {:?}", source_path));
         let sub_dir = sub_dir.join(file_name);
-        for entry in std::fs::read_dir(source_path)
+        for entry in fs::read_dir(source_path)
             .expect("Could not open directory")
             .map(|dir| dir.unwrap())
         {
@@ -237,7 +237,7 @@ fn main_aux() {
     // FIXME: Remove strings that appear in a single file.
 
     // Write dictionaries.
-    DirBuilder::new()
+    fs::DirBuilder::new()
         .recursive(true)
         .create(dest)
         .expect("Could not create directory");

--- a/tests/test_external_roundtrip.rs
+++ b/tests/test_external_roundtrip.rs
@@ -5,6 +5,7 @@ extern crate tempdir;
 
 use tempdir::TempDir;
 
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -50,11 +51,11 @@ fn perform_roundtrip(root: &Path, prefix: &str, source: &str, dictionary: Option
     let path_in_encoded_2 = root.join("encoded_2").join("sample.binjs");
     let path_decoded = root.join("decoded.js");
 
-    let mut dir_builder = std::fs::DirBuilder::new();
+    let mut dir_builder = fs::DirBuilder::new();
     dir_builder.recursive(true).create(root).unwrap();
 
     // Copy source file to `path_tmp_source`, to normalize file name.
-    std::fs::copy(&path_in_source, &path_tmp_source).unwrap();
+    fs::copy(&path_in_source, &path_tmp_source).unwrap();
 
     debug!(target: "test", "Encoding to encoded_1/sample.binjs");
     let mut command_1 = Command::new("target/debug/binjs_encode");
@@ -81,7 +82,7 @@ fn perform_roundtrip(root: &Path, prefix: &str, source: &str, dictionary: Option
     run(command_2).unwrap();
 
     // Copy again to `path_tmp_source`, to normalize file name.
-    std::fs::copy(&path_decoded, &path_tmp_source).unwrap();
+    fs::copy(&path_decoded, &path_tmp_source).unwrap();
 
     debug!(target: "test", "Re-encoding to encoded_2/sample.binjs");
     let mut command_3 = Command::new("target/debug/binjs_encode");
@@ -97,9 +98,9 @@ fn perform_roundtrip(root: &Path, prefix: &str, source: &str, dictionary: Option
     run(command_3).unwrap();
 
     debug!(target: "test", "Comparing the two decoded files");
-    let encoded_1 = std::fs::read(&path_in_encoded_1)
+    let encoded_1 = fs::read(&path_in_encoded_1)
         .unwrap_or_else(|e| panic!("Could not open file {:?}: {:?}", path_in_encoded_1, e));
-    let encoded_2 = std::fs::read(&path_in_encoded_2)
+    let encoded_2 = fs::read(&path_in_encoded_2)
         .unwrap_or_else(|e| panic!("Could not open file {:?}: {:?}", path_in_encoded_2, e));
     // First check for distinct lengths, it's a simple error to spot.
     assert_eq!(


### PR DESCRIPTION
These helpers simplify and improve readability of code around reading/writing whole files.