### PR TITLE
Move FromShift conversion to JavaScript land

### DIFF
--- a/src/source/.prettierrc
+++ b/src/source/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 4,
+  "singleQuote": true
+}

--- a/src/source/codegen.js
+++ b/src/source/codegen.js
@@ -8,4 +8,10 @@
 const codegen = require('shift-codegen').default;
 const startJSONStream = require('./start-json-stream');
 
-startJSONStream(ast => codegen(ast));
+startJSONStream({
+    // Mirrors the Rust side of generic value transformations.
+    //
+    // This one takes an AST from the Rust side as an input and applies
+    // a codegen as a transform, returning generated JavaScript back.
+    transform: ast => codegen(ast)
+});

--- a/src/source/from-shift.js
+++ b/src/source/from-shift.js
@@ -1,0 +1,206 @@
+'use strict';
+
+function makeEager(obj) {
+    obj.type = 'Eager' + obj.type;
+}
+
+function dummyDeclaredScope(type) {
+    return {
+        type,
+        declaredNames: [],
+        hasDirectEval: false
+    };
+}
+
+function parameterScopeAndLength(params) {
+    let length = 0;
+    let isSimpleParameterList = true;
+
+    loop: for (let param of params) {
+        switch (param.type) {
+            case 'BindingIdentifier':
+                length++;
+                break;
+            case 'ObjectBinding':
+            case 'ArrayBinding':
+                isSimpleParameterList = false;
+                length++;
+                break;
+            default:
+                isSimpleParameterList = false;
+                break loop;
+        }
+    }
+
+    return {
+        parameterScope: {
+            type: 'AssertedParameterScope',
+            paramNames: [],
+            hasDirectEval: false,
+            isSimpleParameterList
+        },
+        length
+    };
+}
+
+function dummyBoundNamesScope() {
+    return {
+        type: 'AssertedBoundNamesScope',
+        boundNames: [],
+        hasDirectEval: true
+    };
+}
+
+function createFunctionContents(obj) {
+    let kind = obj.type;
+
+    let directives = obj.body.directives || [];
+    delete obj.body.directives;
+
+    let isExpressionBody;
+    let body = obj.body;
+    delete obj.body;
+
+    if (body.type === 'FunctionBody') {
+        body = body.statements;
+        isExpressionBody = false;
+    } else {
+        isExpressionBody = true;
+    }
+
+    let contents;
+
+    switch (kind) {
+        case 'FunctionDeclaration':
+        case 'Method':
+            contents = {
+                type: 'FunctionOrMethodContents',
+                isThisCaptured: false
+            };
+            break;
+        case 'FunctionExpression':
+            contents = {
+                type: 'FunctionExpressionContents',
+                isFunctionNameCaptured: false,
+                isThisCaptured: false
+            };
+            break;
+        case 'ArrowExpression':
+            if (isExpressionBody) {
+                contents = { type: 'ArrowExpressionContentsWithExpression' };
+                obj.type = 'ArrowExpressionWithExpression';
+            } else {
+                contents = { type: 'ArrowExpressionContentsWithFunctionBody' };
+                obj.type = 'ArrowExpressionWithFunctionBody';
+            }
+            break;
+        case 'Getter':
+            contents = {
+                type: 'GetterContents',
+                isThisCaptured: false
+            };
+            break;
+        case 'Setter': {
+            let { param } = obj;
+            delete obj.param;
+            let { parameterScope, length } = parameterScopeAndLength([param]);
+            contents = {
+                type: 'SetterContents',
+                isThisCaptured: false,
+                param,
+                parameterScope
+            };
+            obj.length = length;
+            break;
+        }
+        default:
+            throw new TypeError(`Unexpected function kind ${kind}`);
+    }
+
+    if (kind !== 'Getter' && kind !== 'Setter') {
+        let { params } = obj;
+        delete obj.params;
+
+        contents.params = params;
+
+        let { parameterScope, length } = parameterScopeAndLength(params.items);
+
+        contents.parameterScope = parameterScope;
+        obj.length = length;
+        obj.isAsync = !!obj.isAsync;
+    }
+
+    contents.bodyScope = dummyDeclaredScope('AssertedVarScope');
+    contents.body = body;
+
+    obj.contents = contents;
+    obj.directives = directives;
+
+    makeEager(obj);
+}
+
+function convertObject(obj) {
+    switch (obj.type) {
+        case 'BlockStatement':
+            obj = obj.block;
+        // fallthrough to handle the unwrapped `Block` node
+        case 'Block':
+            obj.scope = dummyDeclaredScope('AssertedBlockScope');
+            break;
+        case 'ForInStatement':
+        case 'ForOfStatement': {
+            let { left } = obj;
+            if (left.type === 'VariableDeclaration') {
+                left.type = 'ForInOfBinding';
+                left.binding = left.declarators[0].binding;
+                delete left.declarators;
+            }
+            break;
+        }
+        case 'FunctionDeclaration':
+        case 'Method':
+        case 'FunctionExpression':
+        case 'ArrowExpression':
+        case 'Getter':
+        case 'Setter':
+            createFunctionContents(obj);
+            break;
+        case 'LabeledStatement':
+            obj.type = 'LabelledStatement';
+            break;
+        case 'LiteralRegExpExpression': {
+            let flags = '';
+            if (obj.global) flags += 'g';
+            if (obj.ignoreCase) flags += 'i';
+            if (obj.multiLine) flags += 'm';
+            if (obj.sticky) flags += 'y';
+            if (obj.unicode) flags += 'u';
+            obj.flags = flags;
+            break;
+        }
+        case 'Script':
+            obj.scope = dummyDeclaredScope('AssertedScriptGlobalScope');
+            break;
+        case 'CatchClause':
+            obj.bindingScope = dummyBoundNamesScope();
+            break;
+        case 'StaticPropertyName':
+            obj.type = 'LiteralPropertyName';
+            break;
+        case 'VariableDeclarationStatement':
+            // We don't have a `VariableDeclaration` handler, so, unlike with
+            // `BlockStatement`, no need for a fallthrough here.
+            obj = obj.declaration;
+            break;
+    }
+    return obj;
+}
+
+// This is a replacer callback for JSON.stringify to convert Shift AST to BinaryAST JSON.
+module.exports = function convert(_key, value) {
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        return convertObject(value);
+    } else {
+        return value;
+    }
+};

--- a/src/source/parse_file.js
+++ b/src/source/parse_file.js
@@ -1,16 +1,25 @@
 /**
  * This CLI "daemon" expects file paths to JavaScript files as JSON strings
- * on the stdin and will parse them and produce Shift AST objects as JSON
+ * on the stdin and will parse them and produce BinaryAST objects as JSON
  * on stdout.
  */
 
- 'use strict';
+'use strict';
 
 const { readFileSync } = require('fs');
 const { parseScript } = require('shift-parser');
 const startJSONStream = require('./start-json-stream');
 
-startJSONStream(filename => {
-	let code = readFileSync(filename, 'utf-8');
-	return parseScript(code, { earlyErrors: false });
+startJSONStream({
+    // Mirrors the Rust side of generic value transformations.
+    //
+    // This one takes a file path from the Rust side as an input, reads its
+    // contents and parses into a Shift AST.
+    transform: filename => {
+        let code = readFileSync(filename, 'utf-8');
+        return parseScript(code, { earlyErrors: false });
+    },
+    // `toJSON` is a `JSON.stringify` replacer callback that converts Shift AST
+    // to a BinaryAST JSON format on the fly.
+    toJSON: require('./from-shift')
 });

--- a/src/source/parse_str.js
+++ b/src/source/parse_str.js
@@ -1,6 +1,6 @@
 /**
  * This CLI "daemon" expects JSON strings containing JavaScript code on the
- * stdin and will parse them and produce Shift AST objects as JSON on stdout.
+ * stdin and will parse them and produce BinaryAST objects as JSON on stdout.
  */
 
 'use strict';
@@ -8,4 +8,14 @@
 const { parseScript } = require('shift-parser');
 const startJSONStream = require('./start-json-stream');
 
-startJSONStream(code => parseScript(code, { earlyErrors: false }));
+startJSONStream({
+    // Mirrors the Rust side of generic value transformations.
+    //
+    // This one takes a JavaScript source code from the Rust side as an input
+    // and parses it into a Shift AST.
+    transform: code => parseScript(code, { earlyErrors: false }),
+
+    // `toJSON` is a `JSON.stringify` replacer callback that converts Shift AST
+    // to a BinaryAST JSON format on the fly.
+    toJSON: require('./from-shift')
+});

--- a/src/source/start-json-stream.js
+++ b/src/source/start-json-stream.js
@@ -14,32 +14,38 @@ const split = require('split');
 
 // See crates/binjs_io/src/escaped_wtf8.rs
 function escapeWTF8(s) {
-  return s.replace(/[\u007F\uD800-\uDFFF]/gu, m => {
-    if (m == '\u007F') {
-      {
-        return '\u007F007F';
-      }
-    }
-    return '\u007F' + m.charCodeAt(0).toString(16);
-  });
+    return s.replace(/[\u007F\uD800-\uDFFF]/gu, m => {
+        if (m == '\u007F') {
+            return '\u007F007F';
+        }
+        return '\u007F' + m.charCodeAt(0).toString(16);
+    });
 }
 
 /**
- * This API should be called with a callback which simply accepts a parsed input
- * and either returns an output value or throws.
- *
- * JSON parsing, serialisation and error handling will be taken care of.
+ * This API should be called with following options:
+ * @param {object} opts
+ * @param {function=} opts.fromJSON - An optional JSON.parse reviver (see MDN).
+ * @param {function} opts.transform - A callback that transforms a parsed value and either returns a result or throws.
+ * @param {function=} opts.toJSON - An optional JSON.stringify reviver (see MDN).
  */
-module.exports = mapper =>
-  process.stdin
-    .pipe(split(line => {
-        line = JSON.parse(line);
-        try {
-          line = { type: 'Ok', value: mapper(line) };
-        } catch (e) {
-          line = { type: 'Err', value: e.message };
-        }
-        line = escapeWTF8(JSON.stringify(line));
-        return line + '\n';
-      }, null, { trailing: false }))
-    .pipe(process.stdout);
+module.exports = ({ fromJSON, transform, toJSON }) =>
+    process.stdin
+        .pipe(
+            split(
+                line => {
+                    try {
+                        line = JSON.parse(line, fromJSON);
+                        line = transform(line);
+                        line = { type: 'Ok', value: line };
+                        line = escapeWTF8(JSON.stringify(line, toJSON));
+                    } catch (e) {
+                        line = { type: 'Err', value: e.message };
+                    }
+                    return line + '\n';
+                },
+                null,
+                { trailing: false }
+            )
+        )
+        .pipe(process.stdout);

--- a/src/source/to-shift.js
+++ b/src/source/to-shift.js
@@ -1,0 +1,31 @@
+'use strict';
+
+function removeFunctionContents(obj) {
+    obj.type = obj.type.replace(/^(?:Eager|Lazy)/, '');
+
+    delete obj.isAsync;
+    delete obj.scope;
+    delete obj.contents_skip;
+    delete obj.length;
+
+    let { params, body } = obj.contents;
+    delete obj.contents;
+
+    obj.params = params;
+
+    if (obj.type === 'ArrowExpressionWithExpression') {
+        obj.type = 'ArrowExpression';
+        obj.body = body;
+    } else {
+        if (obj.type === 'ArrowExpressionWithFunctionBody') {
+            obj.type = 'ArrowExpression';
+        }
+        obj.body = {
+            type: 'FunctionBody',
+            directives: obj.directives,
+            statements: body
+        };
+    }
+}
+
+function convertObject(key, value) {}


### PR DESCRIPTION
This is the first part of #342 that should make it easier to switch between JSON parsers (or avoid them altogether when used from WASM).

It's mostly manual line-by-line conversion with the exception of using a simpler syntax in JS where possible.

Tests seem to pass, but would love a careful look from someone else as manual conversions tend to be easily error-prone.

Angular parsing benchmark shows ~8% regression in parsing times, but I think we'll easily gain that back longer term by avoiding JSON AST.