### PR TITLE
Eliminate dynamic trait object in Encoder::encode

### DIFF
--- a/crates/binjs_es6/src/io.rs
+++ b/crates/binjs_es6/src/io.rs
@@ -396,7 +396,7 @@ impl Encoder {
         path: Option<&std::path::Path>,
         format: &mut binjs_io::Format,
         ast: &AST,
-    ) -> Result<Box<AsRef<[u8]>>, TokenWriterError>
+    ) -> Result<Box<[u8]>, TokenWriterError>
     where
         Serializer<TokenWriterTreeAdapter<binjs_io::simple::TreeTokenWriter>>: Serialization<AST>,
         Serializer<TokenWriterTreeAdapter<binjs_io::multipart::TreeTokenWriter>>:
@@ -411,8 +411,7 @@ impl Encoder {
                 let writer = binjs_io::simple::TreeTokenWriter::new();
                 let mut serializer = Serializer::new(TokenWriterTreeAdapter::new(writer));
                 serializer.serialize(ast, &mut io_path)?;
-                let data = serializer.done()?;
-                Ok(Box::new(data))
+                serializer.done()
             }
             binjs_io::Format::Multipart {
                 ref mut targets, ..
@@ -420,23 +419,20 @@ impl Encoder {
                 let writer = binjs_io::multipart::TreeTokenWriter::new(targets.clone());
                 let mut serializer = Serializer::new(TokenWriterTreeAdapter::new(writer));
                 serializer.serialize(ast, &mut io_path)?;
-                let data = serializer.done()?;
-                Ok(Box::new(data))
+                serializer.done()
             }
 
             binjs_io::Format::XML => {
                 let writer = binjs_io::xml::Encoder::new();
                 let mut serializer = Serializer::new(TokenWriterTreeAdapter::new(writer));
                 serializer.serialize(ast, &mut io_path)?;
-                let data = serializer.done()?;
-                Ok(Box::new(data))
+                serializer.done()
             }
             binjs_io::Format::JSON => {
                 let writer = binjs_io::binjs_json::write::TreeTokenWriter::new();
                 let mut serializer = Serializer::new(writer);
                 serializer.serialize(ast, &mut io_path)?;
-                let data = serializer.done()?;
-                Ok(Box::new(data))
+                serializer.done()
             }
             binjs_io::Format::Entropy { ref options } => {
                 // FIXME: Extract strings + frequency.
@@ -444,8 +440,7 @@ impl Encoder {
                 let writer = binjs_io::entropy::write::Encoder::new(path, (*options).clone());
                 let mut serializer = Serializer::new(writer);
                 serializer.serialize(ast, &mut io_path)?;
-                let data = serializer.done()?;
-                Ok(Box::new(data))
+                serializer.done()
             }
         }
     }

--- a/crates/binjs_io/src/binjs_json/write.rs
+++ b/crates/binjs_io/src/binjs_json/write.rs
@@ -72,7 +72,7 @@ impl TreeTokenWriter {
 }
 
 impl TokenWriter for TreeTokenWriter {
-    type Data = Vec<u8>;
+    type Data = Box<[u8]>;
 
     fn done(mut self) -> Result<Self::Data, TokenWriterError> {
         match self.contexts.pop() {
@@ -81,7 +81,7 @@ impl TokenWriter for TreeTokenWriter {
                     .pop()
                     .expect("There should be only one item at the top level");
                 let source = json::stringify_pretty(top_level_item, 2);
-                let result = escaped_wtf8::to_unicode_escape(source).as_bytes().to_vec();
+                let result = escaped_wtf8::to_unicode_escape(source).into_bytes().into();
                 Ok(result)
             }
             _ => {

--- a/crates/binjs_io/src/bytes/atoms.rs
+++ b/crates/binjs_io/src/bytes/atoms.rs
@@ -5,18 +5,8 @@ use std::io::{ Error, ErrorKind, Read, Write };
 
 use bytes::varnum::*;
 
-pub trait ToBytes {
-    fn to_bytes(&self) -> Vec<u8>;
-}
-
 pub trait FromBytes where Self: Sized {
     fn from_bytes(&[u8]) -> Result<Self, Error>;
-}
-
-impl ToBytes for String {
-    fn to_bytes(&self) -> Vec<u8> {
-        return self.bytes().collect();
-    }
 }
 
 impl FromBytes for String {

--- a/crates/binjs_io/src/bytes/float.rs
+++ b/crates/binjs_io/src/bytes/float.rs
@@ -10,10 +10,10 @@ const NONE_FLOAT_REPR: u64 = 0x7FF0000000000001;
 const VARNUM_PREFIX_FLOAT: [u8; 2] = VARNUM_INVALID_ZERO_1;
 const VARNUM_NULL: [u8; 3] = VARNUM_INVALID_ZERO_2;
 
-pub fn varbytes_of_float(value: Option<f64>) -> Vec<u8> {
+pub fn varbytes_of_float(value: Option<f64>) -> Box<[u8]> {
     let mut buf = Vec::with_capacity(4);
     buf.write_maybe_varfloat(value).unwrap(); // The write cannot fail on a Vec<>
-    buf
+    buf.into()
 }
 
 /// Encode a f64 | null, little-endian

--- a/crates/binjs_io/src/entropy/write/mod.rs
+++ b/crates/binjs_io/src/entropy/write/mod.rs
@@ -397,7 +397,7 @@ impl Encoder {
 }
 
 impl TokenWriter for Encoder {
-    type Data = Vec<u8>;
+    type Data = Box<[u8]>;
 
     fn done(self) -> Result<Self::Data, TokenWriterError> {
         let mut data: Vec<u8> = Vec::with_capacity(INITIAL_BUFFER_SIZE_BYTES);
@@ -465,7 +465,7 @@ impl TokenWriter for Encoder {
 
         // Update number of instances
         *self.options.content_instances.borrow_mut() += self.content_instances;
-        Ok(data)
+        Ok(data.into())
     }
 
     // --- Fixed set

--- a/crates/binjs_io/src/xml.rs
+++ b/crates/binjs_io/src/xml.rs
@@ -98,7 +98,7 @@ impl Encoder {
 }
 impl TokenWriterWithTree for Encoder {
     type Tree = Rc<SubTree>;
-    type Data = Vec<u8>;
+    type Data = Box<[u8]>;
 
     fn bool(&mut self, data: Option<bool>) -> Result<Self::Tree, TokenWriterError> {
         self.register(SubTree::Bool(data))
@@ -148,7 +148,7 @@ impl TokenWriterWithTree for Encoder {
                 .create_writer(&mut buf);
             self.root.write(&mut writer).unwrap();
         }
-        Ok(buf)
+        Ok(buf.into())
     }
 }
 


### PR DESCRIPTION
Before this, Encoder::encode was wrapping a heap-allocated data into another heap-allocated dynamic trait object.

This is inefficient and unnecessary, so I changed encoders to just return plain Box<[u8]> data.