### PR TITLE
Unescape escaped WTF-8 properly in binjs_deode (fixes #350)

### DIFF
--- a/src/source/from-shift.js
+++ b/src/source/from-shift.js
@@ -202,7 +202,7 @@ function escapeWTF8(s) {
         if (m == '\u007F') {
             return '\u007F007F';
         }
-        return '\u007F' + m.charCodeAt(0).toString(16);
+        return '\u007F' + m.charCodeAt(0).toString(16).toUpperCase();
     });
 }
 

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -12,6 +12,7 @@ use std::process::*;
 use std::sync::Mutex;
 
 use binjs_generic::syntax::{ASTError, MutASTVisitor, MutASTWalker, WalkPath};
+use binjs_io::escaped_wtf8;
 use binjs_meta::spec::{Interface, NodeName, Spec};
 
 use source::parser::SourceParser;
@@ -158,6 +159,7 @@ impl Shift {
             .transform(&ast)
             .and_then(|mut res| {
                 res.take_string()
+                    .map(escaped_wtf8::to_unicode_escape)
                     .ok_or_else(|| Error::JsonError(json::Error::wrong_type("string")))
             })
             .map_err(|err| {

--- a/tests/data/misc/lone-surrogate.js
+++ b/tests/data/misc/lone-surrogate.js
@@ -1,0 +1,4 @@
+var escape_character = "";
+var lead_surrogate = "<\uD83D>";
+var trail_surrogate = "<\uDC38>";
+var surrogate_pair = "<\uD83D\uDC38>";

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -22,9 +22,10 @@ use std::thread;
 /// a `CHANCES_TO_SKIP` probability of being skipped.
 const CHANCES_TO_SKIP: f64 = 0.9;
 
-const PATHS: [&'static str; 2] = [
+const PATHS: [&'static str; 3] = [
     "tests/data/facebook/single/**/*.js",
     "tests/data/frameworks/*.js",
+    "tests/data/misc/*.js",
 ];
 
 fn progress() {


### PR DESCRIPTION
There were 2 issues:

  - input is not unescaped in `codegen.js`
    - so the output of `codegen` is escaped twice
  - source is not unescaped before writing to file in `decode.rs`
    - so the decoded file is still escaped twice

So:

 - added `inputIsEscapedWTF8` parameter to `start-json-stream.js`
   - if it's `true`, input is unescaped before handling
 - use `inputIsEscapedWTF8` in `codegen.js`
 - unescape the output of `Shift` in `decode.rs`
