### PR TITLE
Apply escapeWTF8 only on strings in AST

### DIFF
--- a/src/source/from-shift.js
+++ b/src/source/from-shift.js
@@ -196,10 +196,22 @@ function convertObject(obj) {
     return obj;
 }
 
+// See crates/binjs_io/src/escaped_wtf8.rs
+function escapeWTF8(s) {
+    return s.replace(/[\u007F\uD800-\uDFFF]/gu, m => {
+        if (m == '\u007F') {
+            return '\u007F007F';
+        }
+        return '\u007F' + m.charCodeAt(0).toString(16);
+    });
+}
+
 // This is a replacer callback for JSON.stringify to convert Shift AST to BinaryAST JSON.
 module.exports = function convert(_key, value) {
     if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
         return convertObject(value);
+    } else if (typeof value === 'string') {
+        return escapeWTF8(value);
     } else {
         return value;
     }

--- a/src/source/start-json-stream.js
+++ b/src/source/start-json-stream.js
@@ -12,16 +12,6 @@
 
 const split = require('split');
 
-// See crates/binjs_io/src/escaped_wtf8.rs
-function escapeWTF8(s) {
-    return s.replace(/[\u007F\uD800-\uDFFF]/gu, m => {
-        if (m == '\u007F') {
-            return '\u007F007F';
-        }
-        return '\u007F' + m.charCodeAt(0).toString(16);
-    });
-}
-
 /**
  * This API should be called with following options:
  * @param {object} opts
@@ -38,7 +28,7 @@ module.exports = ({ fromJSON, transform, toJSON }) =>
                         line = JSON.parse(line, fromJSON);
                         line = transform(line);
                         line = { type: 'Ok', value: line };
-                        line = escapeWTF8(JSON.stringify(line, toJSON));
+                        line = JSON.stringify(line, toJSON);
                     } catch (e) {
                         line = { type: 'Err', value: e.message };
                     }


### PR DESCRIPTION
Basically I think it's right to do this first - we shouldn't be applying `escapeWTF8` on result of the codegen in the first place (or on error messages), only on string values in the AST.

This should partially help with #350 but will still need some of your changes in #351.