### PR TITLE
 Abstract away AST <-> JSON conversions in Rust

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,7 +7,6 @@ extern crate binjs;
 #[macro_use]
 extern crate lazy_static;
 
-use binjs::generic::*;
 use binjs::source::*;
 
 const PATHS: &[&str] = &["tests/data/frameworks/angular.1.6.5.min.js"];
@@ -33,7 +32,7 @@ fn bench_parsing_aux(parser: Option<&Shift>, bencher: &mut bencher::Bencher) {
         bencher.iter(move || {
             let shift;
 
-            let json = match parser {
+            match parser {
                 Some(parser) => parser,
                 None => {
                     shift = launch_shift();
@@ -41,9 +40,7 @@ fn bench_parsing_aux(parser: Option<&Shift>, bencher: &mut bencher::Bencher) {
                 }
             }
             .parse_file(path)
-            .expect("Could not parse source");
-
-            binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST")
+            .expect("Could not parse source")
         });
     }
 }

--- a/crates/binjs_shared/src/json_conversion.rs
+++ b/crates/binjs_shared/src/json_conversion.rs
@@ -147,9 +147,9 @@ where
 pub trait ToJSON {
     fn export(&self) -> JSON;
 }
-impl ToJSON for String {
+impl ToJSON for str {
     fn export(&self) -> JSON {
-        json::from(self.clone())
+        json::from(self)
     }
 }
 impl ToJSON for bool {

--- a/examples/compare_compression.rs
+++ b/examples/compare_compression.rs
@@ -9,7 +9,6 @@ extern crate glob;
 extern crate itertools;
 extern crate tempdir;
 
-use binjs::generic::FromJSON;
 use binjs::source::*;
 
 use clap::*;
@@ -129,11 +128,10 @@ fn main() {
             let from_text = get_compressed_sizes(&source_path);
 
             eprintln!("Compressing with binjs");
-            let json = parser
+            let mut ast = parser
                 .parse_file(source_path.clone())
                 .expect("Could not parse source");
-            let mut ast =
-                binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST");
+
             binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
 
             let data = encoder

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -116,7 +116,7 @@ Note that this tool does not attempt to make sure that the files are entirely co
             binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
         }
 
-        if let Ok(source) = parser.to_source(&json) {
+        if let Ok(source) = parser.to_source(&ast) {
             i += 1;
 
             println!("Generated sample {}/{}", i, number);

--- a/examples/sample_directory.rs
+++ b/examples/sample_directory.rs
@@ -6,7 +6,6 @@ extern crate clap;
 extern crate rand;
 extern crate separator;
 
-use binjs::generic::FromJSON;
 use binjs::io::entropy::dictionary::{DictionaryBuilder, Options as DictionaryOptions};
 use binjs::io::entropy::write::Encoder;
 use binjs::io::entropy::Options;
@@ -176,17 +175,10 @@ fn main() {
             // Skip files that are too small.
             continue;
         }
-        let json = if let Ok(json) = parser.parse_file(&entry.default_path) {
-            json
-        } else {
-            // Could not parse source
-            continue;
-        };
-
-        let mut ast = if let Ok(ast) = binjs::specialized::es6::ast::Script::import(&json) {
+        let mut ast = if let Ok(ast) = parser.parse_file(&entry.default_path) {
             ast
         } else {
-            // Could not import AST.
+            // Could not parse source
             continue;
         };
 
@@ -220,17 +212,10 @@ fn main() {
             continue;
         }
 
-        let json = if let Ok(json) = parser.parse_file(&entry.default_path) {
-            json
-        } else {
-            // Could not parse source
-            continue;
-        };
-
-        let mut ast = if let Ok(ast) = binjs::specialized::es6::ast::Script::import(&json) {
+        let mut ast = if let Ok(ast) = parser.parse_file(&entry.default_path) {
             ast
         } else {
-            // Could not import AST.
+            // Could not parse source
             continue;
         };
 

--- a/src/bin/decode.rs
+++ b/src/bin/decode.rs
@@ -111,16 +111,15 @@ fn main_aux() {
         }
     };
 
-    let json = tree.export();
     if options.print_json {
         progress!(quiet, "Printing to screen...");
-        let pretty = json.pretty(2);
+        let pretty = tree.export().pretty(2);
         println!("{}", pretty);
     }
 
     progress!(quiet, "Pretty-printing");
     let printer = Shift::try_new().expect("Could not launch Shift");
-    let source = printer.to_source(&json).expect("Could not pretty-print");
+    let source = printer.to_source(&tree).expect("Could not pretty-print");
 
     progress!(quiet, "Writing.");
     match options.dest_path {

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -4,7 +4,6 @@ extern crate binjs;
 extern crate clap;
 extern crate env_logger;
 
-use binjs::generic::FromJSON;
 use binjs::io::{CompressionTarget, Format};
 use binjs::source::{Shift, SourceParser};
 use binjs::specialized::es6::ast::Walker;
@@ -123,7 +122,7 @@ fn handle_path<'a>(options: &mut Options<'a>, source_path: &Path, sub_dir: &Path
 }
 
 fn handle_path_or_text<'a>(options: &mut Options<'a>, params: EncodeParams) {
-    let (source_path, source_len, json) = match params.source {
+    let (source_path, source_len, mut ast) = match params.source {
         Source::FromFile { path } => (
             Some(path),
             fs::metadata(path).expect("Could not open source").len(),
@@ -144,8 +143,6 @@ fn handle_path_or_text<'a>(options: &mut Options<'a>, params: EncodeParams) {
     let dest_bin_path = params.dest_bin_path;
     let dest_txt_path = params.dest_txt_path;
 
-    let mut ast =
-        binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST");
     binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
 
     if options.lazification > 0 {

--- a/src/bin/generate_dictionary.rs
+++ b/src/bin/generate_dictionary.rs
@@ -6,7 +6,6 @@ extern crate bincode;
 extern crate clap;
 extern crate env_logger;
 
-use binjs::generic::FromJSON;
 use binjs::io::entropy::dictionary::{DictionaryBuilder, Options as DictionaryOptions};
 use binjs::io::{Path as IOPath, Serialization, TokenSerializer};
 use binjs::source::{Shift, SourceParser};
@@ -78,13 +77,11 @@ fn handle_path_or_text<'a>(
     shared_number_of_files: &mut usize,
     source: &Path,
 ) {
-    let json = options
+    let mut ast = options
         .parser
         .parse_file(source)
         .expect("Could not parse source");
 
-    let mut ast =
-        binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST");
     binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
 
     if options.lazification > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ extern crate binjs_io;
 extern crate binjs_meta;
 extern crate binjs_shared;
 
-#[cfg_attr(test, macro_use)]
 extern crate json;
 extern crate which;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,6 @@ extern crate binjs_shared;
 
 #[cfg_attr(test, macro_use)]
 extern crate json;
-#[macro_use]
-extern crate log;
 extern crate which;
 
 #[cfg(test)]

--- a/src/source/parser.rs
+++ b/src/source/parser.rs
@@ -1,15 +1,13 @@
 use std::fmt::Debug;
 use std::path::Path;
 
-use json::JsonValue as JSON;
-
-/// A source that can parse files to JSON ASTs.
-pub trait SourceParser {
+/// A source that can parse files to ASTs.
+pub trait SourceParser<AST> {
     type Error: Debug;
 
     /// Parse a string.
-    fn parse_str(&self, source: &str) -> Result<JSON, Self::Error>;
+    fn parse_str(&self, source: &str) -> Result<AST, Self::Error>;
 
     /// Parse a file.
-    fn parse_file<P: AsRef<Path>>(&self, path: P) -> Result<JSON, Self::Error>;
+    fn parse_file<P: AsRef<Path>>(&self, path: P) -> Result<AST, Self::Error>;
 }

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -179,56 +179,33 @@ fn test_shift_basic() {
     use env_logger;
     env_logger::init();
 
+    use binjs_es6::ast::*;
+    use binjs_shared::IdentifierName;
+
     let shift = Shift::try_new().expect("Could not launch Shift");
 
     let parsed = shift
         .parse_str("function foo() {}")
         .expect("Error in parse_str");
 
-    let expected = ScriptAST::import(&object! {
-        "type" => "Script",
-        "directives" => array![],
-        "scope" => object!{
-            "type" => "AssertedScriptGlobalScope",
-            "declaredNames" => array![],
-            "hasDirectEval" => false,
-        },
-        "statements" => array![
-            object!{
-                "type" => "EagerFunctionDeclaration",
-                "isGenerator" => false,
-                "isAsync" => false,
-                "length" => 0,
-                "name" => object!{
-                    "type" => "BindingIdentifier",
-                    "name" => "foo"
+    let expected = Script {
+        statements: vec![Statement::EagerFunctionDeclaration(Box::new(
+            EagerFunctionDeclaration {
+                name: BindingIdentifier {
+                    name: IdentifierName::from_str("foo"),
                 },
-                "directives" => array![],
-                "contents" => object!{
-                    "type" => "FunctionOrMethodContents",
-                    "isThisCaptured" => false,
-                    "parameterScope" => object!{
-                        "type" => "AssertedParameterScope",
-                        "paramNames" => array![],
-                        "hasDirectEval" => false,
-                        "isSimpleParameterList" => true,
+                contents: FunctionOrMethodContents {
+                    parameter_scope: AssertedParameterScope {
+                        is_simple_parameter_list: true,
+                        ..Default::default()
                     },
-                    "params" => object!{
-                        "type" => "FormalParameters",
-                        "items" => array![],
-                        "rest" => json::Null,
-                    },
-                    "bodyScope" => object!{
-                        "type" => "AssertedVarScope",
-                        "declaredNames" => array![],
-                        "hasDirectEval" => false,
-                    },
-                    "body" => array![],
-                }
-            }
-        ]
-    })
-    .unwrap();
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ))],
+        ..Default::default()
+    };
 
     assert!(parsed == expected, "{:#?} != {:#?}", parsed, expected);
 }

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -9,7 +9,7 @@ use std::path::*;
 use std::process::*;
 use std::sync::Mutex;
 
-use binjs_es6::ast::Script as ScriptAST;
+use binjs_es6::ast::Script as AST;
 use binjs_io::escaped_wtf8;
 use binjs_shared::{FromJSON, FromJSONError, ToJSON};
 
@@ -149,22 +149,22 @@ impl Shift {
         })
     }
 
-    pub fn to_source(&self, ast: &ScriptAST) -> Result<String, Error> {
+    pub fn to_source(&self, ast: &AST) -> Result<String, Error> {
         self.codegen
             .transform(ast)
             .map(escaped_wtf8::to_unicode_escape)
     }
 }
 
-impl SourceParser<ScriptAST> for Shift {
+impl SourceParser<AST> for Shift {
     type Error = Error;
 
-    fn parse_str(&self, data: &str) -> Result<ScriptAST, Error> {
+    fn parse_str(&self, data: &str) -> Result<AST, Error> {
         self.parse_str.transform(data)
     }
 
     /// Parse a text source file, using Shift.
-    fn parse_file<P: AsRef<Path>>(&self, path: P) -> Result<ScriptAST, Error> {
+    fn parse_file<P: AsRef<Path>>(&self, path: P) -> Result<AST, Error> {
         let path = path
             .as_ref()
             .to_str()

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -19,7 +19,7 @@ use which::which;
 pub enum Error {
     CouldNotLaunch(std::io::Error),
     IOError(std::io::Error),
-    JsonError(json::Error),
+    JSONError(json::Error),
     InvalidPath(PathBuf),
     NodeNotFound(which::Error),
     ParsingError(String),
@@ -98,7 +98,7 @@ impl Script {
         })()
         .map_err(Error::IOError)?;
 
-        let result = json::parse(&output).map_err(Error::JsonError)?;
+        let result = json::parse(&output).map_err(Error::JSONError)?;
         if let JSON::Object(mut obj) = result {
             if let (Some(mut value), Some(ty)) = (
                 obj.remove("value"),
@@ -115,7 +115,7 @@ impl Script {
                 }
             }
         }
-        Err(Error::JsonError(json::Error::wrong_type(
+        Err(Error::JSONError(json::Error::wrong_type(
             "Result-like JSON object",
         )))
     }
@@ -150,7 +150,7 @@ impl Shift {
             .and_then(|mut res| {
                 res.take_string()
                     .map(escaped_wtf8::to_unicode_escape)
-                    .ok_or_else(|| Error::JsonError(json::Error::wrong_type("string")))
+                    .ok_or_else(|| Error::JSONError(json::Error::wrong_type("string")))
             })
             .map_err(|err| {
                 warn!("Could not pretty-print {}", ast.pretty(2));

--- a/src/source/shift.rs
+++ b/src/source/shift.rs
@@ -124,9 +124,10 @@ impl Script {
                 }
             }
         }
-        Err(Error::JSONError(json::Error::wrong_type(
-            "Result-like JSON object",
-        )))
+        Err(Error::FromJSONError(FromJSONError {
+            expected: "Result-like JSON object".to_string(),
+            got: output,
+        }))
     }
 }
 

--- a/tests/test_dictionary_builder.rs
+++ b/tests/test_dictionary_builder.rs
@@ -1,7 +1,7 @@
 extern crate binjs;
 extern crate itertools;
 
-use binjs::generic::{FromJSON, IdentifierName, InterfaceName, Offset, PropertyKey, SharedString};
+use binjs::generic::{IdentifierName, InterfaceName, Offset, PropertyKey, SharedString};
 use binjs::io::entropy;
 use binjs::io::entropy::dictionary::{
     DictionaryBuilder, FilesContaining, LinearTable, Options as DictionaryOptions,
@@ -49,9 +49,7 @@ test!(test_entropy_roundtrip, {
     );
     for source in &dict_sources {
         println!("Parsing");
-        let ast = parser.parse_str(source).expect("Could not parse source");
-        let mut ast =
-            binjs::specialized::es6::ast::Script::import(&ast).expect("Could not import AST");
+        let mut ast = parser.parse_str(source).expect("Could not parse source");
 
         println!("Annotating");
         binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
@@ -184,12 +182,10 @@ test!(test_entropy_roundtrip, {
 
 fn test_with_options<S>(parser: &S, source: &str, options: &entropy::Options)
 where
-    S: SourceParser,
+    S: SourceParser<Script>,
 {
     println!("Parsing with dictionary: {}", source);
-    let reference = parser.parse_str(source).expect("Could not parse source");
-    let mut reference =
-        binjs::specialized::es6::ast::Script::import(&reference).expect("Could not import AST");
+    let mut reference = parser.parse_str(source).expect("Could not parse source");
 
     println!("Reannotating");
     binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut reference);

--- a/tests/test_paths.rs
+++ b/tests/test_paths.rs
@@ -7,9 +7,7 @@
 
 extern crate binjs;
 
-use binjs::generic::{
-    FieldName, FromJSON, IdentifierName, InterfaceName, Node, PropertyKey, SharedString,
-};
+use binjs::generic::{FieldName, IdentifierName, InterfaceName, Node, PropertyKey, SharedString};
 use binjs::io::{Serialization, TokenWriter, TokenWriterError};
 use binjs::source::{Shift, SourceParser};
 use binjs::specialized::es6::io::IOPath;
@@ -177,8 +175,7 @@ test!(test_es6_paths, {
     let source = "function foo(x, y) { var i; for (i = 0; i < 100; ++i) { console.log(x, y + i, x + y + i, x + y + i + 1); } }";
 
     println!("Parsing");
-    let ast = parser.parse_str(source).expect("Could not parse source");
-    let mut ast = binjs::specialized::es6::ast::Script::import(&ast).expect("Could not import AST");
+    let mut ast = parser.parse_str(source).expect("Could not parse source");
 
     println!("Annotating");
     binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -115,11 +115,10 @@ fn main() {
 
             // Parse and preprocess file.
 
-            let json = parser
+            let mut ast = parser
                 .parse_file(entry.clone())
                 .expect("Could not parse source");
-            let mut ast =
-                binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST");
+
             binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
 
             // Immutable copy.
@@ -185,11 +184,10 @@ fn main() {
             // Parse and preprocess file.
 
             eprint!("\n{:?}.", entry);
-            let json = parser
+            let mut ast = parser
                 .parse_file(entry.clone())
                 .expect("Could not parse source");
-            let mut ast =
-                binjs::specialized::es6::ast::Script::import(&json).expect("Could not import AST");
+
             binjs::specialized::es6::scopes::AnnotationVisitor::new().annotate_script(&mut ast);
 
             {


### PR DESCRIPTION
This makes parser and codegen both easier to use and maintain, since the primary public API doesn't rely on a specific JSON parser implementation anymore.