### PR TITLE
Preparing AST visitor for injection of scoped dictionary changes.

### DIFF
--- a/crates/binjs_es6/src/lazy.rs
+++ b/crates/binjs_es6/src/lazy.rs
@@ -28,6 +28,13 @@ impl Drop for LevelGuard {
     }
 }
 
+/// Trivial implementation of the constructor for `Option<LevelGuard>`.
+impl<'a> From<&'a LazifierVisitor> for Option<LevelGuard> {
+    fn from(_: &'a LazifierVisitor) -> Self {
+        None
+    }
+}
+
 /// A visitor in charge of rewriting an AST to introduce laziness.
 pub struct LazifierVisitor {
     /// A nesting level at which to stop.

--- a/crates/binjs_es6/src/scopes.rs
+++ b/crates/binjs_es6/src/scopes.rs
@@ -622,6 +622,13 @@ fn maybe_exit_destructuring_parameter(visitor: &mut AnnotationVisitor, path: &Wa
     visitor.binding_kind_stack.pop();
 }
 
+/// A trivial constructor for our guards.
+impl<'a> From<&'a AnnotationVisitor> for () {
+    fn from(_: &'a AnnotationVisitor) -> () {
+        ()
+    }
+}
+
 impl Visitor<()> for AnnotationVisitor {
     // Identifiers
 
@@ -1282,6 +1289,14 @@ struct EvalCleanupAnnotator {
     /// `true` if name `eval` was bound at this level or higher in the tree.
     eval_bindings: Vec<bool>,
 }
+
+/// A trivial constructor for our trivial guards.
+impl<'a> From<&'a EvalCleanupAnnotator> for () {
+    fn from(_: &'a EvalCleanupAnnotator) -> () {
+        ()
+    }
+}
+
 impl Visitor<()> for EvalCleanupAnnotator {
     // FIXME: Anything that has a scope (including CatchClause and its invisible scope) should push an `eval_bindings`.
     // on entering, pop it on exit.

--- a/tests/test_dictionary_builder.rs
+++ b/tests/test_dictionary_builder.rs
@@ -30,6 +30,12 @@ impl Visitor<()> for OffsetCleanerVisitor {
         Ok(())
     }
 }
+/// A trivial constructor for our trivial guards.
+impl<'a> From<&'a OffsetCleanerVisitor> for () {
+    fn from(_: &'a OffsetCleanerVisitor) -> () {
+        ()
+    }
+}
 
 test!(test_entropy_roundtrip, {
     let parser = Shift::try_new().expect("Could not launch Shift");

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -50,6 +50,12 @@ impl Visitor<()> for OffsetCleanerVisitor {
         Ok(())
     }
 }
+/// A trivial constructor for our trivial guards.
+impl<'a> From<&'a OffsetCleanerVisitor> for () {
+    fn from(_: &'a OffsetCleanerVisitor) -> () {
+        ()
+    }
+}
 
 #[test]
 fn test_roundtrip() {


### PR DESCRIPTION
This patch contains two small changes for the AST visitor:

- guards now take as argument the visitor, instead of no argument;
- implementing a method `ViewMut*::steal()` to recover the underlying value.