### PR TITLE
Move comments inside macros.

### DIFF
--- a/crates/binjs_io/src/entropy/mod.rs
+++ b/crates/binjs_io/src/entropy/mod.rs
@@ -94,7 +94,14 @@ use std::rc::Rc;
 /// }
 /// ```
 macro_rules! const_with_str {
-    ( $(const $const_name: ident: $ty: ty = $init: expr;)* mod $mod_name: ident;) => {
+    (
+        $(#[$outer:meta])*
+        $(const $const_name: ident: $ty: ty = $init: expr;)*
+        mod $mod_name: ident;
+    ) => {
+        // Documentation comments are actually syntactic sugar for #[doc="Some documentation comment"].
+        // We capture them and insert them in the generated macro.
+        $(#[$outer])*
         mod $mod_name {
             $(pub const $const_name: &'static str = stringify!($init);)*
         }
@@ -102,17 +109,18 @@ macro_rules! const_with_str {
     }
 }
 
-/// The number of indices to reserve to recall
-/// recently used values in a content stream.
-///
-/// In issue #302, we have established that identifier_names
-/// seems to benefit of a window length of 8, and others
-/// a window length of 0.
-///
-/// The macro call generates a module `arg_as_str` holding the
-/// string representations of the consts. Used for the `clap`
-/// default args.
 const_with_str! {
+    /// The number of indices to reserve to recall
+    /// recently used values in a content stream.
+    ///
+    /// In issue #302, we have established that identifier_names
+    /// seems to benefit of a window length of 8, and others
+    /// a window length of 0.
+    ///
+    /// The macro call generates a module `arg_as_str` holding the
+    /// string representations of the consts. Used for the `clap`
+    /// default args.
+
     const DEFAULT_WINDOW_LEN_FLOATS: usize = 0;
     const DEFAULT_WINDOW_LEN_UNSIGNED_LONGS: usize = 0;
     const DEFAULT_WINDOW_LEN_PROPERTY_KEYS: usize = 0;

--- a/crates/binjs_shared/src/lib.rs
+++ b/crates/binjs_shared/src/lib.rs
@@ -31,18 +31,26 @@ pub enum VisitMe<T> {
     DoneHere,
 }
 
-/// An identifier, inside the grammar.
-shared_string!(pub IdentifierName);
+shared_string!(
+    /// An identifier, inside the grammar.
+    pub IdentifierName
+);
 pub type Identifier = IdentifierName;
 
-/// A property, inside the grammar.
-shared_string!(pub PropertyKey);
+shared_string!(
+    /// A property, inside the grammar.
+    pub PropertyKey
+);
 
-/// An interface *of* the grammar.
-shared_string!(pub InterfaceName);
+shared_string!(
+    /// An interface *of* the grammar.
+    pub InterfaceName
+);
 
-/// A field name *of* the grammar.
-shared_string!(pub FieldName);
+shared_string!(
+    /// A field name *of* the grammar.
+    pub FieldName
+);
 
 /// A container for f64 values that implements an *arbitrary*
 /// total order, equality relation, hash.

--- a/crates/binjs_shared/src/shared_string.rs
+++ b/crates/binjs_shared/src/shared_string.rs
@@ -95,7 +95,13 @@ impl SharedString {
 
 #[macro_export]
 macro_rules! shared_string {
-    (pub $name: ident) => {
+    (
+        $(#[$outer:meta])*
+        pub $name: ident
+    ) => {
+        // Documentation comments are actually syntactic sugar for #[doc="Some documentation comment"].
+        // We capture them and insert them in the generated macro.
+        $(#[$outer])*
         #[derive(Clone, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize)]
         pub struct $name(pub shared_string::SharedString);
         impl $name {


### PR DESCRIPTION
Documentation generated by rustdoc ignores comments such as

```rust
/// Documentation
use_a_macro_to_declare_a_type_or_value!(...)
```

This patch tweaks our macro declarations to recognize documentation
comments and turn them into actual comments recognized by rustdoc.

As a side-effect, it fixes warnings on Rust nightly.