### PR TITLE
Set the default dictionary depth to 2 in generate_dictionary . issue 363

### DIFF
--- a/src/bin/generate_dictionary.rs
+++ b/src/bin/generate_dictionary.rs
@@ -152,7 +152,7 @@ fn main_aux() {
             Arg::with_name("depth")
                 .long("depth")
                 .takes_value(true)
-                .default_value("3")
+                .default_value("2")
                 .validator(|s| s.parse::<u32>()
                     .map(|_| ())
                     .map_err(|e| format!("Invalid number {}", e)))


### PR DESCRIPTION
Set the default dictionary depth to 2 in generate_dictionary . issue 363