### PR TITLE
Making annotations more robust

### DIFF
--- a/crates/binjs_es6/Cargo.toml
+++ b/crates/binjs_es6/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 assert_matches = "^1.0"
 binjs_io = { path = "../binjs_io/", version = "*" }
 binjs_shared = { path = "../binjs_shared/", version = "*" }
+clap = "^2"
 itertools = "^0.7"
 serde = { version = "^1.0", features = ["derive"] }
 log = "^0.4"

--- a/crates/binjs_es6/src/lazy.rs
+++ b/crates/binjs_es6/src/lazy.rs
@@ -1,10 +1,14 @@
 use ast::*;
+use EnrichError;
 
 use binjs_shared::{Offset, VisitMe};
 
 use std;
 use std::cell::RefCell;
 use std::rc::Rc;
+
+type EnterResult = Result<VisitMe<Option<LevelGuard>>, EnrichError>;
+type ExitResult<T> = Result<Option<T>, EnrichError>;
 
 /// Keep track of the number of nested levels of functions/methods/...
 /// we have crossed.
@@ -58,16 +62,15 @@ impl LazifierVisitor {
             level: Rc::new(RefCell::new(0)),
         }
     }
-    pub fn annotate_script(&mut self, script: &mut Script) {
-        script
-            .walk(&mut WalkPath::new(), self)
-            .expect("Could not walk script");
+    pub fn annotate_script(&mut self, script: &mut Script) -> Result<(), EnrichError> {
+        script.walk(&mut WalkPath::new(), self)?;
+        Ok(())
     }
 }
 
 impl LazifierVisitor {
     /// Hack to steal a subtree from a `&mut`.
-    fn steal<T: Default, F, U>(source: &mut T, decorator: F) -> Result<Option<U>, ()>
+    fn steal<T: Default, F, U>(source: &mut T, decorator: F) -> ExitResult<U>
     where
         F: FnOnce(T) -> U,
     {
@@ -81,7 +84,7 @@ impl LazifierVisitor {
     /// Return `DoneHere` if we're beyond the threshold, hence skipping the subtree.
     /// Otherwise, acquire a `LevelGuard` that will be released once we're done
     /// with this subtree.
-    fn cut_at_threshold(&mut self) -> Result<VisitMe<Option<LevelGuard>>, ()> {
+    fn cut_at_threshold(&mut self) -> EnterResult {
         {
             if *self.level.borrow() >= self.threshold {
                 return Ok(VisitMe::DoneHere);
@@ -91,13 +94,13 @@ impl LazifierVisitor {
     }
 }
 
-impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
+impl Visitor<EnrichError, Option<LevelGuard>> for LazifierVisitor {
     /// Skip subtrees that are beyond the threshold.
     fn enter_method_definition(
         &mut self,
         _path: &WalkPath,
         _node: &mut ViewMutMethodDefinition,
-    ) -> Result<VisitMe<Option<LevelGuard>>, ()> {
+    ) -> EnterResult {
         self.cut_at_threshold()
     }
 
@@ -108,7 +111,7 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         &mut self,
         _path: &WalkPath,
         node: &mut ViewMutMethodDefinition,
-    ) -> Result<Option<MethodDefinition>, ()> {
+    ) -> ExitResult<MethodDefinition> {
         match *node {
             ViewMutMethodDefinition::EagerGetter(ref mut steal) => Self::steal(*steal, |stolen| {
                 LazyGetter {
@@ -150,7 +153,7 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         &mut self,
         _path: &WalkPath,
         _node: &mut ViewMutFunctionDeclaration,
-    ) -> Result<VisitMe<Option<LevelGuard>>, ()> {
+    ) -> EnterResult {
         self.cut_at_threshold()
     }
 
@@ -161,7 +164,7 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         &mut self,
         _path: &WalkPath,
         node: &mut ViewMutFunctionDeclaration,
-    ) -> Result<Option<FunctionDeclaration>, ()> {
+    ) -> ExitResult<FunctionDeclaration> {
         match *node {
             ViewMutFunctionDeclaration::EagerFunctionDeclaration(ref mut steal) => {
                 Self::steal(*steal, |stolen| {
@@ -186,7 +189,7 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         &mut self,
         _path: &WalkPath,
         _node: &mut ViewMutFunctionExpression,
-    ) -> Result<VisitMe<Option<LevelGuard>>, ()> {
+    ) -> EnterResult {
         self.cut_at_threshold()
     }
 
@@ -197,7 +200,7 @@ impl Visitor<(), Option<LevelGuard>> for LazifierVisitor {
         &mut self,
         path: &WalkPath,
         node: &mut ViewMutFunctionExpression,
-    ) -> Result<Option<FunctionExpression>, ()> {
+    ) -> ExitResult<FunctionExpression> {
         // Don't lazify code that's going to be used immediately.
         if let Some(WalkPathItem {
             interface: ASTNode::CallExpression,

--- a/crates/binjs_es6/src/lib.rs
+++ b/crates/binjs_es6/src/lib.rs
@@ -26,8 +26,12 @@ pub mod io;
 /// which we do not support yet.
 #[derive(Debug)]
 pub enum EnrichError {
-    /// While analyzing scopes, we exit a binding identifier but there is no binding kind.
-    MissingBindingKind,
+    ScopeError(scopes::ScopeError),
+}
+impl From<scopes::ScopeError> for EnrichError {
+    fn from(err: scopes::ScopeError) -> Self {
+        EnrichError::ScopeError(err)
+    }
 }
 
 /// A mechanism used to enrich an AST obtained from parsing with additional information

--- a/crates/binjs_es6/src/lib.rs
+++ b/crates/binjs_es6/src/lib.rs
@@ -4,10 +4,12 @@
 
 #[macro_use]
 extern crate binjs_io;
+#[macro_use]
 extern crate binjs_shared;
 
 #[macro_use]
 extern crate assert_matches;
+extern crate clap;
 extern crate itertools;
 #[macro_use]
 extern crate serde;
@@ -55,17 +57,71 @@ pub struct Enrich {
     /// Default: `None` (deactivated), as this is an optional, WIP, optimization.
     pub pure_data_threshold: Option<usize>,
 }
+const_with_str! {
+    const DEFAULT_SCOPES: bool = true;
+    const DEFAULT_LAZY_THRESHOLD: u32 = 0;
+    const DEFAULT_PURE_DATA_THRESHOLD: Option<usize> = None;
+    mod defaults_as_strings;
+}
 
 impl Default for Enrich {
     fn default() -> Self {
         Enrich {
-            scopes: true,
-            lazy_threshold: 0,
-            pure_data_threshold: None,
+            scopes: DEFAULT_SCOPES,
+            lazy_threshold: DEFAULT_LAZY_THRESHOLD,
+            pure_data_threshold: DEFAULT_PURE_DATA_THRESHOLD,
         }
     }
 }
 impl Enrich {
+    pub fn args<'a, 'b>(&self) -> Vec<clap::Arg<'a, 'b>> {
+        use clap::*;
+        vec![
+            Arg::with_name("inject-lazy")
+                .long("inject-lazy")
+                .alias("lazify")
+                .takes_value(true)
+                .value_name("LEVEL")
+                .help("Rewrite the AST for all functions strictly below level LEVEL. Do nothing if LEVEL = 0")
+                .default_value(defaults_as_strings::DEFAULT_LAZY_THRESHOLD),
+            Arg::with_name("inject-scopes")
+                .long("inject-scopes")
+                .takes_value(true)
+                .help("Rewrite the AST to provide scope information.")
+                .default_value(defaults_as_strings::DEFAULT_SCOPES)
+                .possible_values(&["true", "false"]),
+            Arg::with_name("inject-json-specialization")
+                .long("inject-json-specialization")
+                .value_name("SIZE")
+                .takes_value(true)
+                .help("Rewrite the AST to introduce scoped dictionary changes around pure data fragments with size >= SIZE")
+                .default_value(defaults_as_strings::DEFAULT_PURE_DATA_THRESHOLD),
+        ]
+    }
+
+    pub fn from_matches(matches: &clap::ArgMatches) -> Self {
+        use std::str::FromStr;
+        let scopes = match matches.value_of("inject-scopes") {
+            Some("true") => true,
+            Some("false") => false,
+            other => panic!("Unexpected value for inject-scopes: {:?}", other),
+        };
+        let lazy_threshold = u32::from_str(matches.value_of("inject-lazy").unwrap())
+            .unwrap_or_else(|e| panic!("Error parsing inject-lazy: {:?}", e));
+        let pure_data_threshold = match matches.value_of("inject-json-specialization").unwrap() {
+            "none" | "None" => None,
+            other => Some(
+                usize::from_str(other)
+                    .unwrap_or_else(|e| panic!("Error parsing inject-lazy: {:?}", e)),
+            ),
+        };
+        Enrich {
+            scopes,
+            lazy_threshold,
+            pure_data_threshold,
+        }
+    }
+
     /// Perform enrichments.
     pub fn enrich(&self, script: &mut ast::Script) -> Result<(), EnrichError> {
         if self.lazy_threshold > 0 {

--- a/crates/binjs_es6/src/sublanguages.rs
+++ b/crates/binjs_es6/src/sublanguages.rs
@@ -6,9 +6,13 @@
 
 use ast::*;
 use binjs_shared::{SharedString, VisitMe};
+use EnrichError;
 
 use std::cell::RefCell;
 use std::rc::Rc;
+
+type EnterResult = Result<VisitMe<PropertiesGuard>, EnrichError>;
+type ExitResult<T> = Result<Option<T>, EnrichError>;
 
 /// The name of the dictionary used to represent pure data subtrees (aka "JSON").
 ///
@@ -144,9 +148,6 @@ impl WalkGuard<InjectVisitor> for PropertiesGuard {
     }
 }
 
-type EnterResult = Result<VisitMe<PropertiesGuard>, ()>;
-type ExitResult<T> = Result<Option<T>, ()>;
-
 impl InjectVisitor {
     pub fn new(pure_data_threshold: usize) -> Self {
         Self {
@@ -154,11 +155,13 @@ impl InjectVisitor {
             stack: Rc::new(RefCell::new(Vec::new())),
         }
     }
-    pub fn rewrite_script(pure_data_threshold: usize, script: &mut Script) {
+    pub fn rewrite_script(
+        pure_data_threshold: usize,
+        script: &mut Script,
+    ) -> Result<(), EnrichError> {
         let mut visitor = Self::new(pure_data_threshold);
-        script
-            .walk(&mut WalkPath::new(), &mut visitor)
-            .expect("Could not walk script");
+        script.walk(&mut WalkPath::new(), &mut visitor)?;
+        Ok(())
     }
 
     /// The properties of the current node.
@@ -176,7 +179,7 @@ impl InjectVisitor {
         }
     }
 }
-impl Visitor<(), PropertiesGuard> for InjectVisitor {
+impl Visitor<EnrichError, PropertiesGuard> for InjectVisitor {
     // --- Literals
 
     fn enter_literal<'a>(&mut self, path: &WalkPath, node: &mut ViewMutLiteral<'a>) -> EnterResult {
@@ -324,7 +327,7 @@ impl Visitor<()> for CleanupVisitor {
         &mut self,
         _path: &WalkPath,
         node: &mut ViewMutExpression<'a>,
-    ) -> ExitResult<Expression> {
+    ) -> Result<Option<Expression>, ()> {
         if let ViewMutExpression::BinASTExpressionWithProbabilityTable(_) = *node {
             if let Expression::BinASTExpressionWithProbabilityTable(scoped) = node.steal() {
                 Ok(Some(scoped.expression))
@@ -349,7 +352,8 @@ mod test {
     fn check(threshold: usize, source: Script, expected: Script) {
         // Rewrite.
         let mut injected = source.clone();
-        InjectVisitor::rewrite_script(threshold, &mut injected);
+        InjectVisitor::rewrite_script(threshold, &mut injected)
+            .unwrap();
         assert_eq!(injected, expected);
 
         // Rewrite back.

--- a/crates/binjs_es6/src/sublanguages.rs
+++ b/crates/binjs_es6/src/sublanguages.rs
@@ -352,8 +352,7 @@ mod test {
     fn check(threshold: usize, source: Script, expected: Script) {
         // Rewrite.
         let mut injected = source.clone();
-        InjectVisitor::rewrite_script(threshold, &mut injected)
-            .unwrap();
+        InjectVisitor::rewrite_script(threshold, &mut injected).unwrap();
         assert_eq!(injected, expected);
 
         // Rewrite back.

--- a/crates/binjs_io/src/entropy/mod.rs
+++ b/crates/binjs_io/src/entropy/mod.rs
@@ -76,41 +76,6 @@ use binjs_shared::SharedString;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// From a set of macro definitions, derive a module with a set of matching `&'static str`.
-///
-/// Example:
-/// ```rust,no_run
-/// const_with_str {
-///    const FOO: usize = 0;
-///    mod my_strings;
-/// }
-/// ```
-///
-/// will produce
-///
-/// ```rust,no_run
-///
-/// const FOO: usize = 0;
-/// mod my_strings {
-///   const FOO: &'static str = "0";
-/// }
-/// ```
-macro_rules! const_with_str {
-    (
-        $(#[$outer:meta])*
-        $(const $const_name: ident: $ty: ty = $init: expr;)*
-        mod $mod_name: ident;
-    ) => {
-        // Documentation comments are actually syntactic sugar for #[doc="Some documentation comment"].
-        // We capture them and insert them in the generated macro.
-        $(#[$outer])*
-        mod $mod_name {
-            $(pub const $const_name: &'static str = stringify!($init);)*
-        }
-        $(const $const_name: $ty = $init;)*
-    }
-}
-
 const_with_str! {
     /// The number of indices to reserve to recall
     /// recently used values in a content stream.

--- a/crates/binjs_io/src/lib.rs
+++ b/crates/binjs_io/src/lib.rs
@@ -1,5 +1,7 @@
 extern crate bincode; // Used to store dictionaries. This is a temporary format.
 extern crate binjs_meta;
+
+#[macro_use]
 extern crate binjs_shared;
 
 extern crate brotli;

--- a/crates/binjs_shared/src/lib.rs
+++ b/crates/binjs_shared/src/lib.rs
@@ -106,3 +106,46 @@ pub type IOPathItem = ast::PathItem<
         /* field name */ FieldName,
     ),
 >;
+
+/// From a set of macro definitions, derive a module with a set of matching `&'static str`.
+///
+/// Example:
+///
+/// ```rust,no_run
+/// # #[macro_use]
+/// # extern crate binjs_shared;
+/// # fn main() {
+///
+/// const_with_str! {
+///    const FOO: usize = 0;
+///    mod my_strings;
+/// }
+///
+/// # }
+/// ```
+///
+/// will produce
+///
+/// ```rust,no_run
+///
+/// const FOO: usize = 0;
+/// mod my_strings {
+///   const FOO: &'static str = "0";
+/// }
+/// ```
+#[macro_export]
+macro_rules! const_with_str {
+    (
+        $(#[$outer:meta])*
+        $(const $const_name: ident: $ty: ty = $init: expr;)*
+        mod $mod_name: ident;
+    ) => {
+        // Documentation comments are actually syntactic sugar for #[doc="Some documentation comment"].
+        // We capture them and insert them in the generated macro.
+        $(#[$outer])*
+        mod $mod_name {
+            $(pub const $const_name: &'static str = stringify!($init);)*
+        }
+        $(const $const_name: $ty = $init;)*
+    }
+}

--- a/examples/compare_compression.rs
+++ b/examples/compare_compression.rs
@@ -133,8 +133,7 @@ fn main() {
                 .expect("Could not parse source");
 
             let enricher = binjs::specialized::es6::Enrich::default();
-            enricher.enrich(&mut ast)
-                .expect("Could not enrich AST");
+            enricher.enrich(&mut ast).expect("Could not enrich AST");
 
             let data = encoder
                 .encode(None, &mut format, &ast)

--- a/examples/compare_compression.rs
+++ b/examples/compare_compression.rs
@@ -133,7 +133,8 @@ fn main() {
                 .expect("Could not parse source");
 
             let enricher = binjs::specialized::es6::Enrich::default();
-            enricher.enrich(&mut ast);
+            enricher.enrich(&mut ast)
+                .expect("Could not enrich AST");
 
             let data = encoder
                 .encode(None, &mut format, &ast)

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -110,7 +110,8 @@ Note that this tool does not attempt to make sure that the files are entirely co
             scopes: !random_metadata,
             ..Default::default()
         };
-        enricher.enrich(&mut ast);
+        enricher.enrich(&mut ast)
+            .expect("Could not enrich AST");
 
         if let Ok(source) = parser.to_source(&ast) {
             i += 1;

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -110,8 +110,7 @@ Note that this tool does not attempt to make sure that the files are entirely co
             scopes: !random_metadata,
             ..Default::default()
         };
-        enricher.enrich(&mut ast)
-            .expect("Could not enrich AST");
+        enricher.enrich(&mut ast).expect("Could not enrich AST");
 
         if let Ok(source) = parser.to_source(&ast) {
             i += 1;

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -7,6 +7,7 @@ extern crate env_logger;
 use binjs::io::{CompressionTarget, Format};
 use binjs::source::{Shift, SourceParser};
 use binjs::specialized::es6::io::Encoder;
+use binjs::specialized::es6::Enrich;
 
 use std::fs;
 use std::io::*;
@@ -34,7 +35,7 @@ struct Options<'a> {
     parser: &'a Shift,
     format: Format,
     dest_dir: Option<PathBuf>,
-    lazification: u32,
+    enricher: Enrich,
     show_ast: bool,
     quiet: bool,
 }
@@ -142,12 +143,10 @@ fn handle_path_or_text<'a>(options: &mut Options<'a>, params: EncodeParams) {
     let dest_bin_path = params.dest_bin_path;
     let dest_txt_path = params.dest_txt_path;
 
-    let enricher = binjs::specialized::es6::Enrich {
-        lazy_threshold: options.lazification,
-        scopes: true,
-        ..Default::default()
-    };
-    enricher.enrich(&mut ast).expect("Could not enrich AST");
+    options
+        .enricher
+        .enrich(&mut ast)
+        .expect("Could not enrich AST");
 
     if options.show_ast {
         serde_json::to_writer_pretty(std::io::stdout(), &ast).unwrap();
@@ -243,19 +242,15 @@ fn main_aux() {
             Arg::with_name("show-ast")
                 .long("show-ast")
                 .help("Show pos-processed ast"),
-            Arg::with_name("lazify")
-                .long("lazify")
-                .takes_value(true)
-                .default_value("0")
-                .validator(|s| s.parse::<u32>()
-                    .map(|_| ())
-                    .map_err(|e| format!("Invalid number {}", e)))
-                .help("Number of layers of functions to lazify. 0 = no lazification, 1 = functions at toplevel, 2 = also functions in functions at toplevel, etc."),
             Arg::with_name("quiet")
                 .long("quiet")
                 .short("q")
                 .help("Do not print progress"),
         ])
+        .args(Enrich {
+            scopes: true,
+            ..Default::default()
+        }.args().as_slice())
         .subcommand(binjs::io::Format::subcommand())
         .get_matches();
 
@@ -285,19 +280,18 @@ fn main_aux() {
         binjs::io::Format::from_matches(&spec, &matches).expect("Could not parse encoding format");
     progress!(quiet, "Using format: {}", format.name());
 
+    let enricher = Enrich::from_matches(&matches);
+
     let show_stats = matches.is_present("statistics");
 
     // Setup.
     let parser = Shift::try_new().expect("Could not launch Shift");
 
-    let lazification =
-        str::parse(matches.value_of("lazify").expect("Missing lazify")).expect("Invalid number");
-
     let mut options = Options {
         parser: &parser,
         format,
         dest_dir,
-        lazification,
+        enricher,
         show_ast: matches.is_present("show-ast"),
         quiet,
     };

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -147,7 +147,7 @@ fn handle_path_or_text<'a>(options: &mut Options<'a>, params: EncodeParams) {
         scopes: true,
         ..Default::default()
     };
-    enricher.enrich(&mut ast);
+    enricher.enrich(&mut ast).expect("Could not enrich AST");
 
     if options.show_ast {
         serde_json::to_writer_pretty(std::io::stdout(), &ast).unwrap();

--- a/src/bin/generate_dictionary.rs
+++ b/src/bin/generate_dictionary.rs
@@ -9,6 +9,7 @@ extern crate env_logger;
 use binjs::io::entropy::dictionary::{DictionaryBuilder, Options as DictionaryOptions};
 use binjs::io::{Path as IOPath, Serialization, TokenSerializer};
 use binjs::source::{Shift, SourceParser};
+use binjs::specialized::es6::Enrich;
 
 use std::fs::{self, File};
 use std::path::Path;
@@ -18,7 +19,7 @@ use clap::*;
 
 struct Options<'a> {
     parser: &'a Shift,
-    lazification: u32,
+    enricher: Enrich,
     quiet: bool,
     show_ast: bool,
 }
@@ -82,12 +83,10 @@ fn handle_path_or_text<'a>(
         .parse_file(source)
         .expect("Could not parse source");
 
-    let enricher = binjs::specialized::es6::Enrich {
-        lazy_threshold: options.lazification,
-        scopes: true,
-        ..Default::default()
-    };
-    enricher.enrich(&mut ast).expect("Could not enrich AST");
+    options
+        .enricher
+        .enrich(&mut ast)
+        .expect("Could not enrich AST");
 
     if options.show_ast {
         serde_json::to_writer_pretty(std::io::stdout(), &ast).unwrap();
@@ -141,14 +140,6 @@ fn main_aux() {
             Arg::with_name("show-ast")
                 .long("show-ast")
                 .help("Show the AST of each source file before extracting the dictionary"),
-            Arg::with_name("lazify")
-                .long("lazify")
-                .takes_value(true)
-                .default_value("0")
-                .validator(|s| s.parse::<u32>()
-                    .map(|_| ())
-                    .map_err(|e| format!("Invalid number {}", e)))
-                .help("Number of layers of functions to lazify. 0 = no lazification, 1 = functions at toplevel, 2 = also functions in functions at toplevel, etc."),
             Arg::with_name("quiet")
                 .long("quiet")
                 .short("q")
@@ -178,6 +169,10 @@ fn main_aux() {
                     .map_err(|e| format!("Invalid number {}", e)))
                 .help("Prune from the dictionary all user-extensible values that appear in at most [threshold] files"),
         ])
+        .args(Enrich {
+            scopes: true,
+            ..Default::default()
+        }.args().as_slice())
         .get_matches();
 
     // Common options.
@@ -189,9 +184,6 @@ fn main_aux() {
 
     let quiet = matches.is_present("quiet");
 
-    let lazification =
-        str::parse(matches.value_of("lazify").expect("Missing lazify")).expect("Invalid number");
-
     let depth = str::parse(matches.value_of("depth").unwrap()).expect("Invalid number");
 
     let width = str::parse(matches.value_of("window-width").unwrap()).expect("Invalid number");
@@ -199,13 +191,7 @@ fn main_aux() {
     let threshold: usize =
         str::parse(matches.value_of("threshold").unwrap()).expect("Invalid number");
 
-    progress!(
-        quiet,
-        "Generating dictionary with lazification {lazification}, depth {depth}, width {width}",
-        lazification = lazification,
-        depth = depth,
-        width = width
-    );
+    let enricher = Enrich::from_matches(&matches);
 
     // Setup.
     let parser = Shift::try_new().expect("Could not launch Shift");
@@ -218,7 +204,7 @@ fn main_aux() {
 
     let mut options = Options {
         parser: &parser,
-        lazification,
+        enricher,
         quiet,
         show_ast: matches.is_present("show-ast"),
     };

--- a/src/bin/generate_dictionary.rs
+++ b/src/bin/generate_dictionary.rs
@@ -87,7 +87,7 @@ fn handle_path_or_text<'a>(
         scopes: true,
         ..Default::default()
     };
-    enricher.enrich(&mut ast);
+    enricher.enrich(&mut ast).expect("Could not enrich AST");
 
     if options.show_ast {
         serde_json::to_writer_pretty(std::io::stdout(), &ast).unwrap();

--- a/tests/test_dictionary_builder.rs
+++ b/tests/test_dictionary_builder.rs
@@ -56,8 +56,7 @@ test!(test_entropy_roundtrip, {
             scopes: true,
             ..Default::default()
         };
-        enricher.enrich(&mut ast)
-            .expect("Could not enrich AST");
+        enricher.enrich(&mut ast).expect("Could not enrich AST");
 
         println!("Extracting dictionary");
         let mut serializer = binjs::specialized::es6::io::Serializer::new(&mut builder);
@@ -197,7 +196,8 @@ where
         scopes: true,
         ..Default::default()
     };
-    enricher.enrich(&mut ast)
+    enricher
+        .enrich(&mut reference)
         .expect("Could not enrich AST");
 
     let mut path = IOPath::new();

--- a/tests/test_dictionary_builder.rs
+++ b/tests/test_dictionary_builder.rs
@@ -56,7 +56,8 @@ test!(test_entropy_roundtrip, {
             scopes: true,
             ..Default::default()
         };
-        enricher.enrich(&mut ast);
+        enricher.enrich(&mut ast)
+            .expect("Could not enrich AST");
 
         println!("Extracting dictionary");
         let mut serializer = binjs::specialized::es6::io::Serializer::new(&mut builder);
@@ -196,7 +197,8 @@ where
         scopes: true,
         ..Default::default()
     };
-    enricher.enrich(&mut reference);
+    enricher.enrich(&mut ast)
+        .expect("Could not enrich AST");
 
     let mut path = IOPath::new();
 

--- a/tests/test_paths.rs
+++ b/tests/test_paths.rs
@@ -182,7 +182,7 @@ test!(test_es6_paths, {
         scopes: true,
         ..Default::default()
     };
-    enricher.enrich(&mut ast);
+    enricher.enrich(&mut ast).expect("Could not enrich AST");
 
     println!("Walking paths");
     let mut serializer = binjs::specialized::es6::io::Serializer::new(writer);

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -106,8 +106,7 @@ fn main() {
                     scopes: false,
                     ..Default::default()
                 };
-                enricher.enrich(&mut ast)
-                    .expect("Could not enrich AST");
+                enricher.enrich(&mut ast).expect("Could not enrich AST");
                 progress();
 
                 let options = Targets {

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -106,7 +106,8 @@ fn main() {
                     scopes: false,
                     ..Default::default()
                 };
-                enricher.enrich(&mut ast);
+                enricher.enrich(&mut ast)
+                    .expect("Could not enrich AST");
                 progress();
 
                 let options = Targets {


### PR DESCRIPTION
We don't necessarily want to panic whenever we cannot enrich a file. This patch is a first step towards converting our Enrich mechanism to something that bails out gracefully whenever it encounters an error.