### PR TITLE
Context 0.2: Prelude decoder

### DIFF
--- a/crates/binjs_io/src/bytes/decoders.rs
+++ b/crates/binjs_io/src/bytes/decoders.rs
@@ -1,0 +1,105 @@
+use TokenReaderError;
+
+use bytes::float::ReadVarFloat;
+use bytes::strings::ReadStr;
+use bytes::varnum::ReadVarNum;
+
+use std::io::Cursor;
+
+pub struct VarFloatDecoder {
+    data: Cursor<Vec<u8>>,
+}
+impl VarFloatDecoder {
+    pub fn new(data: Vec<u8>) -> Self {
+        VarFloatDecoder {
+            data: Cursor::new(data),
+        }
+    }
+}
+impl Iterator for VarFloatDecoder {
+    type Item = Result<Option<binjs_shared::F64>, TokenReaderError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.data.position() == self.data.get_ref().len() as u64 {
+            return None;
+        }
+        match self.data.read_maybe_varfloat() {
+            Ok(Some(result)) => Some(Ok(Some(result.into()))),
+            Ok(None) => Some(Ok(None)),
+            Err(err) => Some(Err(TokenReaderError::ReadError(err))),
+        }
+    }
+}
+
+pub struct MaybeVarNumDecoder {
+    data: Cursor<Vec<u8>>,
+}
+impl MaybeVarNumDecoder {
+    pub fn new(data: Vec<u8>) -> Self {
+        MaybeVarNumDecoder {
+            data: Cursor::new(data),
+        }
+    }
+}
+impl Iterator for MaybeVarNumDecoder {
+    type Item = Result<Option<u32>, TokenReaderError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.data.position() == self.data.get_ref().len() as u64 {
+            return None;
+        }
+        match self.data.read_maybe_varnum() {
+            Ok(result) => Some(Ok(result)),
+            Err(err) => Some(Err(TokenReaderError::ReadError(err))),
+        }
+    }
+}
+
+pub struct StringDecoder {
+    data: Cursor<Vec<u8>>,
+    lengths: Cursor<Vec<u8>>,
+}
+impl StringDecoder {
+    pub fn try_new(
+        data: Option<Vec<u8>>,
+        lengths: Option<Vec<u8>>,
+    ) -> Result<StringDecoder, TokenReaderError> {
+        match (data, lengths) {
+            (Some(data), Some(lengths)) => Ok(Self::new(data, lengths)),
+            (None, None) => Ok(Self::new(vec![], vec![])),
+            _ => Err(TokenReaderError::BadStringDecoder),
+        }
+    }
+    pub fn new(data: Vec<u8>, lengths: Vec<u8>) -> Self {
+        StringDecoder {
+            data: Cursor::new(data),
+            lengths: Cursor::new(lengths),
+        }
+    }
+}
+impl Iterator for StringDecoder {
+    type Item = Result<Option<String>, TokenReaderError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.lengths.position() == self.lengths.get_ref().len() as u64 {
+            debug!(target: "read", "StringDecoder::next - end reached");
+            return None;
+        }
+        fn aux(myself: &mut StringDecoder) -> Result<Option<String>, TokenReaderError> {
+            let byte_len = myself
+                .lengths
+                .read_maybe_varnum()
+                .map_err(TokenReaderError::ReadError)?;
+            match byte_len {
+                None => Ok(None),
+                Some(byte_len) => {
+                    debug!(target: "read", "StringDecoder::next - byte length: {}", byte_len);
+                    let value = myself
+                        .data
+                        .read_string(byte_len as usize)
+                        .map_err(TokenReaderError::ReadError)?;
+                    debug!(target: "read", "StringDecoder::next - value: {:?}", value);
+                    Ok(Some(value))
+                }
+            }
+        }
+        Some(aux(self))
+    }
+}

--- a/crates/binjs_io/src/bytes/mod.rs
+++ b/crates/binjs_io/src/bytes/mod.rs
@@ -6,6 +6,9 @@ pub mod bool;
 /// Compressing/decompressing from/to common formats.
 pub mod compress;
 
+/// Decoders for streams of floats, etc.
+pub mod decoders;
+
 /// Encoding/decoding floating-point numbers.
 pub mod float;
 
@@ -14,6 +17,9 @@ pub mod lengthwriter;
 
 /// Serializing/deserializing traits.
 pub mod serialize;
+
+/// String utilities.
+pub mod strings;
 
 /// Encoding/decoding variable-length numbers.
 pub mod varnum;

--- a/crates/binjs_io/src/bytes/strings.rs
+++ b/crates/binjs_io/src/bytes/strings.rs
@@ -1,0 +1,20 @@
+use std::io::Cursor;
+
+/// Utility: An extension of `Read` that reads `bytes` bytes and attempts
+/// to convert them into a string.
+pub trait ReadStr {
+    fn read_string(&mut self, bytes: usize) -> Result<String, std::io::Error>;
+}
+impl ReadStr for Cursor<Vec<u8>> {
+    fn read_string(&mut self, bytes: usize) -> Result<String, std::io::Error> {
+        use std::io::*;
+        let mut buf = Vec::with_capacity(bytes);
+        unsafe {
+            buf.set_len(bytes);
+        }
+        self.read_exact(&mut buf)?;
+        let result = String::from_utf8(buf)
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "Invalid UTF-8 data"))?;
+        Ok(result)
+    }
+}

--- a/crates/binjs_io/src/context/mod.rs
+++ b/crates/binjs_io/src/context/mod.rs
@@ -1,0 +1,8 @@
+//! WIP: Context encoding/decoding.
+
+mod prelude;
+
+/// A four-char name embedded in the binary.
+///
+/// This may typically the name of a section or that of a compression format.
+pub type Name = [u8; 4];

--- a/crates/binjs_io/src/context/prelude.rs
+++ b/crates/binjs_io/src/context/prelude.rs
@@ -1,0 +1,215 @@
+use context::Name;
+use TokenReaderError;
+
+use bytes::varnum::ReadVarNum;
+use util::PosRead;
+
+use std::io::Read;
+
+/// A compression format used in the prelude.
+#[derive(Clone, Debug)]
+pub enum Compression {
+    /// The subsection is compressed using brotli.
+    Brotli,
+    /// The subsection is uncompressed.
+    Identity,
+}
+impl Compression {
+    /// Return the representation as a 4 bytes name.
+    pub fn as_bytes(&self) -> &'static Name {
+        match *self {
+            Compression::Brotli => b"BROT",
+            Compression::Identity => b"NONE",
+        }
+    }
+
+    /// Parse the 4 bytes name.
+    pub fn from_bytes(bytes: &Name) -> Option<Compression> {
+        match bytes {
+            b"BROT" => Some(Compression::Brotli),
+            b"NONE" => Some(Compression::Identity),
+            _ => None,
+        }
+    }
+}
+
+/// The name of a subsection of the prelude.
+#[derive(Clone, Debug)]
+pub enum SubSection {
+    /// Definitions of floating-point values.
+    Float,
+
+    /// Definitions of unsigned longs.
+    UnsignedLong,
+
+    /// Definitions of list lengths.
+    ListLength,
+
+    /// Definitions of property keys: single string concatenation of all property keys.
+    /// Needs `PropertyKeyLen` to be cut back into a sequence of strings.
+    PropertyKeyContent,
+
+    /// Definitions of identifier names, as a single string concatenation of all identifier names.
+    /// Needs `IdentifierNameLen` to be cut back into a sequence of strings.
+    IdentifierNameContent,
+
+    /// Definitions of literal strings, as a single string concatenation of all literal strings.
+    /// Needs `LiteralStringLen` to be cut back into a sequence of strings.
+    LiteralStringContent,
+
+    /// The sequence of length of strings in `PropertyKeyContent`.
+    PropertyKeyLen,
+
+    /// The sequence of length of strings in `IdentifierNameLen`.
+    IdentifierNameLen,
+
+    /// The sequence of length of strings in `LiteralStringLen`.
+    LiteralStringLen,
+}
+impl SubSection {
+    /// Return the representation as a 4 bytes name.
+    pub fn as_bytes(&self) -> &'static Name {
+        match *self {
+            SubSection::Float => b"FLOA",
+            SubSection::UnsignedLong => b"ULON",
+            SubSection::ListLength => b"LIST",
+            SubSection::PropertyKeyContent => b"PROC",
+            SubSection::PropertyKeyLen => b"PROL",
+            SubSection::IdentifierNameContent => b"IDEC",
+            SubSection::IdentifierNameLen => b"IDEL",
+            SubSection::LiteralStringContent => b"STRC",
+            SubSection::LiteralStringLen => b"STRL",
+        }
+    }
+
+    /// Parse the 4 bytes name.
+    pub fn from_bytes(bytes: &Name) -> Option<Self> {
+        match bytes {
+            b"FLOA" => Some(SubSection::Float),
+            b"ULON" => Some(SubSection::UnsignedLong),
+            b"LIST" => Some(SubSection::ListLength),
+            b"PROC" => Some(SubSection::PropertyKeyContent),
+            b"PROL" => Some(SubSection::PropertyKeyLen),
+            b"IDEC" => Some(SubSection::IdentifierNameContent),
+            b"IDEL" => Some(SubSection::IdentifierNameLen),
+            b"STRC" => Some(SubSection::LiteralStringContent),
+            b"STRL" => Some(SubSection::LiteralStringLen),
+            _ => None,
+        }
+    }
+}
+
+/// Decode a prelude into an iterator of subsections.
+pub struct PreludeDecoder<T>
+where
+    T: Read,
+{
+    reader: T,
+    name: Option<Name>,
+}
+impl<T> PreludeDecoder<T>
+where
+    T: Read,
+{
+    /// Create a `PreludeDecoder`.
+    ///
+    /// The `reader` is expected to contain the *content* of the prelude, *without*
+    /// its name `PREL`.
+    pub fn new(reader: T) -> Self {
+        PreludeDecoder { reader, name: None }
+    }
+
+    /// Finalize and recover the reader.
+    pub fn into_input(self) -> T {
+        self.reader
+    }
+
+    /// Return the latest name encountered by the `PreludeDecoder`.
+    ///
+    /// Usually, this is the name of the latest SubSection. However, if we have reached the
+    /// end of the `PreludeDecoder`, this is the name of the next Section
+    pub fn name(&self) -> Option<&Name> {
+        self.name.as_ref()
+    }
+
+    /// Read the next section, update `self.name()`.
+    fn read_stream(&mut self) -> Result<Option<(SubSection, Vec<u8>)>, TokenReaderError> {
+        // Read next name.
+        let mut name = [0; 4];
+        self.reader
+            .read_exact(&mut name)
+            .map_err(TokenReaderError::ReadError)?;
+        let section = SubSection::from_bytes(&name);
+        self.name = Some(name);
+        let section = match section {
+            None => {
+                // We have reached the end of the section.
+                return Ok(None);
+            }
+            Some(section) => section,
+        };
+
+        // Read compression format.
+        let mut name = [0; 4];
+        self.reader
+            .read_exact(&mut name)
+            .map_err(TokenReaderError::ReadError)?;
+        let compression = Compression::from_bytes(&name).ok_or_else(|| {
+            TokenReaderError::BadCompression(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Invalid compression format {:?} for prelude subsection {:?}",
+                    name, section
+                ),
+            ))
+        })?;
+
+        // Read byte length.
+        let byte_len = self
+            .reader
+            .read_varnum()
+            .map_err(TokenReaderError::ReadError)? as usize;
+
+        // Now read and decode data.
+        let data = match compression {
+            Compression::Identity => {
+                let mut result = Vec::with_capacity(byte_len);
+                result.resize_with(byte_len as usize, u8::default);
+                self.reader
+                    .read_exact(&mut result)
+                    .map_err(TokenReaderError::ReadError)?;
+                result
+            }
+            Compression::Brotli => {
+                let mut result = Vec::new();
+                let mut slice = PosRead::new(self.reader.by_ref().take(byte_len as u64));
+                brotli::BrotliDecompress(&mut slice, &mut result)
+                    .map_err(TokenReaderError::ReadError)?;
+                // Ensure that all bytes have been read.
+                if slice.pos() != byte_len {
+                    return Err(TokenReaderError::BadLength {
+                        expected: byte_len,
+                        got: slice.pos(),
+                    });
+                }
+                result
+            }
+        };
+        Ok(Some((section, data)))
+    }
+}
+
+impl<'a, T> Iterator for &'a mut PreludeDecoder<T>
+where
+    T: Read,
+{
+    type Item = Result<(SubSection, Vec<u8>), TokenReaderError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.read_stream() {
+            Ok(Some(result)) => Some(Ok(result)),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+}

--- a/crates/binjs_io/src/entropy/read/mod.rs
+++ b/crates/binjs_io/src/entropy/read/mod.rs
@@ -9,6 +9,7 @@ use super::probabilities::SymbolIndex;
 use super::rw::*;
 use super::util::*;
 
+use bytes::decoders::*;
 use io::{FileStructurePrinter, Path, TokenReader};
 use statistics::PerUserExtensibleKind;
 use TokenReaderError;

--- a/crates/binjs_io/src/entropy/read/prelude_decoders.rs
+++ b/crates/binjs_io/src/entropy/read/prelude_decoders.rs
@@ -6,10 +6,9 @@ use entropy::util::*;
 use util::PosRead;
 use TokenReaderError;
 
-use bytes::float::ReadVarFloat;
 use bytes::varnum::ReadVarNum;
 
-use std::io::{Cursor, Read};
+use std::io::Read;
 
 /// A name read from the prelude.
 ///
@@ -201,103 +200,5 @@ where
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         }
-    }
-}
-
-pub struct VarFloatDecoder {
-    data: Cursor<Vec<u8>>,
-}
-impl VarFloatDecoder {
-    pub fn new(data: Vec<u8>) -> Self {
-        VarFloatDecoder {
-            data: Cursor::new(data),
-        }
-    }
-}
-impl Iterator for VarFloatDecoder {
-    type Item = Result<Option<binjs_shared::F64>, TokenReaderError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.data.position() == self.data.get_ref().len() as u64 {
-            return None;
-        }
-        match self.data.read_maybe_varfloat() {
-            Ok(Some(result)) => Some(Ok(Some(result.into()))),
-            Ok(None) => Some(Ok(None)),
-            Err(err) => Some(Err(TokenReaderError::ReadError(err))),
-        }
-    }
-}
-
-pub struct MaybeVarNumDecoder {
-    data: Cursor<Vec<u8>>,
-}
-impl MaybeVarNumDecoder {
-    pub fn new(data: Vec<u8>) -> Self {
-        MaybeVarNumDecoder {
-            data: Cursor::new(data),
-        }
-    }
-}
-impl Iterator for MaybeVarNumDecoder {
-    type Item = Result<Option<u32>, TokenReaderError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.data.position() == self.data.get_ref().len() as u64 {
-            return None;
-        }
-        match self.data.read_maybe_varnum() {
-            Ok(result) => Some(Ok(result)),
-            Err(err) => Some(Err(TokenReaderError::ReadError(err))),
-        }
-    }
-}
-
-pub struct StringDecoder {
-    data: Cursor<Vec<u8>>,
-    lengths: Cursor<Vec<u8>>,
-}
-impl StringDecoder {
-    pub fn try_new(
-        data: Option<Vec<u8>>,
-        lengths: Option<Vec<u8>>,
-    ) -> Result<StringDecoder, TokenReaderError> {
-        match (data, lengths) {
-            (Some(data), Some(lengths)) => Ok(Self::new(data, lengths)),
-            (None, None) => Ok(Self::new(vec![], vec![])),
-            _ => Err(TokenReaderError::BadStringDecoder),
-        }
-    }
-    pub fn new(data: Vec<u8>, lengths: Vec<u8>) -> Self {
-        StringDecoder {
-            data: Cursor::new(data),
-            lengths: Cursor::new(lengths),
-        }
-    }
-}
-impl Iterator for StringDecoder {
-    type Item = Result<Option<String>, TokenReaderError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.lengths.position() == self.lengths.get_ref().len() as u64 {
-            debug!(target: "read", "StringDecoder::next - end reached");
-            return None;
-        }
-        fn aux(myself: &mut StringDecoder) -> Result<Option<String>, TokenReaderError> {
-            let byte_len = myself
-                .lengths
-                .read_maybe_varnum()
-                .map_err(TokenReaderError::ReadError)?;
-            match byte_len {
-                None => Ok(None),
-                Some(byte_len) => {
-                    debug!(target: "read", "StringDecoder::next - byte length: {}", byte_len);
-                    let value = myself
-                        .data
-                        .read_string(byte_len as usize)
-                        .map_err(TokenReaderError::ReadError)?;
-                    debug!(target: "read", "StringDecoder::next - value: {:?}", value);
-                    Ok(Some(value))
-                }
-            }
-        }
-        Some(aux(self))
     }
 }

--- a/crates/binjs_io/src/entropy/util.rs
+++ b/crates/binjs_io/src/entropy/util.rs
@@ -1,6 +1,6 @@
 //! Miscellaneous utilities used for entropy (de)coding.
 
-use std::io::{Cursor, Read};
+use std::io::Read;
 
 /// Utility: an extension of `Read` with a method `expect` that may be
 /// used to ensure the presence of a sequence of bytes.
@@ -28,24 +28,5 @@ where
             }
         }
         Ok(())
-    }
-}
-
-/// Utility: An extension of `Read` that reads `bytes` bytes and attempts
-/// to conver them into a string.
-pub trait ReadStr {
-    fn read_string(&mut self, bytes: usize) -> Result<String, std::io::Error>;
-}
-impl ReadStr for Cursor<Vec<u8>> {
-    fn read_string(&mut self, bytes: usize) -> Result<String, std::io::Error> {
-        use std::io::*;
-        let mut buf = Vec::with_capacity(bytes);
-        unsafe {
-            buf.set_len(bytes);
-        }
-        self.read_exact(&mut buf)?;
-        let result = String::from_utf8(buf)
-            .map_err(|_| Error::new(ErrorKind::InvalidData, "Invalid UTF-8 data"))?;
-        Ok(result)
     }
 }

--- a/crates/binjs_io/src/lib.rs
+++ b/crates/binjs_io/src/lib.rs
@@ -119,6 +119,9 @@ mod util;
 
 pub mod escaped_wtf8;
 
+/// An encoding using per-context Huffman tables.
+pub mod context;
+
 const ADVANCED_COMMAND: &str = "advanced";
 
 /// A strategy for placing the dictionary.


### PR DESCRIPTION
This patch adds a PreludeDecoder for Context 0.2 and exposes to Context 0.2
the other decoders developed for Entropy 0.4 and that may be reused as such in Context 0.2.