### PR TITLE
Omit `"type"` on enums

### DIFF
--- a/crates/binjs_generate_library/src/lib.rs
+++ b/crates/binjs_generate_library/src/lib.rs
@@ -409,7 +409,7 @@ impl<'a> Walker<'a> for {name} where Self: 'a {{
                         "
 /// Implementation of interface sum {node_name}
 #[derive(PartialEq, Debug, Clone, Serialize)]
-#[serde(tag = \"type\")]
+#[serde(untagged)] // structs already serialize their own tags
 pub enum {name} {{
 {contents}
     /// An additional value used to mark that the node was stolen by a call to `steal()`.


### PR DESCRIPTION
This fixes duplicate "type" keys in JSON output (--show-ast or --print-json) which are caused by the fact that structs already serialise their own tags.