### PR TITLE
Resolve #406 - exit_binding_identifier now handles lazy functions

### DIFF
--- a/tests/data/scope/function_declaration.js
+++ b/tests/data/scope/function_declaration.js
@@ -1,0 +1,2 @@
+// Dedicated to issue #406.
+function foo() { }

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -100,10 +100,11 @@ fn main() {
                 .expect("Could not parse source");
 
             'per_level: for level in &[0, 1, 2, 3, 4, 5] {
+                debug!(target: "test_roundtrip", "Testing {:?} with laziness level {}", entry, level);
                 let mut ast = reference_ast.clone();
                 let enricher = binjs::specialized::es6::Enrich {
                     lazy_threshold: *level,
-                    scopes: false,
+                    scopes: true,
                     ..Default::default()
                 };
                 enricher.enrich(&mut ast).expect("Could not enrich AST");


### PR DESCRIPTION
exit_binding_identifier contains a hard-coded list of nodes that represent
functions. This is hardly ideal (perhaps we should somehow put this in the webidl?)
and at some point, we failed to update this list, causing the bug.