### PR TITLE
Making TypeName more reproducible

### DIFF
--- a/crates/binjs_es6/src/sublanguages.rs
+++ b/crates/binjs_es6/src/sublanguages.rs
@@ -239,10 +239,10 @@ impl Visitor<EnrichError, PropertiesGuard> for InjectVisitor {
 
     // --- Arrays
 
-    fn enter_spread_element_or_expression<'a>(
+    fn enter_expression_or_spread_element<'a>(
         &mut self,
         path: &WalkPath,
-        _node: &mut ViewMutSpreadElementOrExpression<'a>,
+        _node: &mut ViewMutExpressionOrSpreadElement<'a>,
     ) -> EnterResult {
         // Pure data so far.
         Ok(VisitMe::HoldThis(PropertiesGuard::pure_data(self, 1, path)))

--- a/crates/binjs_io/src/lib.rs
+++ b/crates/binjs_io/src/lib.rs
@@ -121,6 +121,7 @@ mod util;
 pub mod escaped_wtf8;
 
 /// An encoding using per-context Huffman tables.
+#[cfg(build_context)]
 pub mod context;
 
 const ADVANCED_COMMAND: &str = "advanced";

--- a/crates/binjs_meta/Cargo.toml
+++ b/crates/binjs_meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binjs_meta"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["David Teller <D.O.Teller@gmail.com>"]
 description = "Part of binjs-ref. Tools for manipulating grammars. You probably do not want to use this crate directly unless you're writing an encoder, decoder or parser generator for binjs."
 homepage = "https://binast.github.io/ecmascript-binary-ast/"

--- a/crates/binjs_meta/Cargo.toml
+++ b/crates/binjs_meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binjs_meta"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["David Teller <D.O.Teller@gmail.com>"]
 description = "Part of binjs-ref. Tools for manipulating grammars. You probably do not want to use this crate directly unless you're writing an encoder, decoder or parser generator for binjs."
 homepage = "https://binast.github.io/ecmascript-binary-ast/"

--- a/crates/binjs_meta/src/export.rs
+++ b/crates/binjs_meta/src/export.rs
@@ -362,9 +362,10 @@ impl TypeDeanonymizer {
                     }
                 }
                 let my_name = match public_name {
-                    None => self
-                        .builder
-                        .node_name(&format!("{}", names.drain(..).format("Or"))),
+                    None => self.builder.node_name(&format!(
+                        "{}",
+                        names.into_iter().sorted().into_iter().format("Or")
+                    )),
                     Some(ref name) => name.clone(),
                 };
                 for subsum_name in subsums {
@@ -420,9 +421,15 @@ impl TypeName {
             TypeSpec::Void => "_Void".to_string(),
             TypeSpec::IdentifierName => "IdentifierName".to_string(),
             TypeSpec::PropertyKey => "PropertyKey".to_string(),
-            TypeSpec::TypeSum(ref sum) => {
-                format!("{}", sum.types().iter().map(Self::type_spec).format("Or"))
-            }
+            TypeSpec::TypeSum(ref sum) => format!(
+                "{}",
+                sum.types()
+                    .iter()
+                    .map(Self::type_spec)
+                    .sorted()
+                    .into_iter()
+                    .format("Or")
+            ),
         }
     }
 }


### PR DESCRIPTION
Currently, `TypeName` produces sum names that can change at each build. Making the order explicit.