### PR TITLE
Fix warning about unnecessary mut

### DIFF
--- a/crates/binjs_meta/src/export.rs
+++ b/crates/binjs_meta/src/export.rs
@@ -348,7 +348,7 @@ impl TypeDeanonymizer {
                 let mut names = vec![];
                 let mut subsums = vec![];
                 for sub_type in sum.types() {
-                    let (mut sub_sum, name) = self.import_typespec(spec, sub_type, None);
+                    let (sub_sum, name) = self.import_typespec(spec, sub_type, None);
                     let mut sub_sum = sub_sum.unwrap_or_else(
                         || panic!("While treating {:?}, attempting to create a sum containing {}, which isn't an interface or a sum of interfaces", type_spec, name)
                     );
@@ -370,7 +370,7 @@ impl TypeDeanonymizer {
                 };
                 for subsum_name in subsums {
                     // So, `my_name` is a superset of `subsum_name`.
-                    let mut supersum_entry = self
+                    let supersum_entry = self
                         .supersums_of
                         .entry(subsum_name.clone())
                         .or_insert_with(|| HashSet::new());

--- a/crates/binjs_meta/src/import.rs
+++ b/crates/binjs_meta/src/import.rs
@@ -258,7 +258,7 @@ impl Importer {
                 .builder
                 .get_typedef_mut(&node_name)
                 .unwrap_or_else(|| panic!("Could not find typedef {}", extended));
-            let mut typespec = typedef.spec_mut();
+            let typespec = typedef.spec_mut();
             let typesum = if let TypeSpec::TypeSum(ref mut typesum) = *typespec {
                 typesum
             } else {

--- a/crates/binjs_meta/src/util.rs
+++ b/crates/binjs_meta/src/util.rs
@@ -294,7 +294,7 @@ where
                 let text = &line[indent_len..];
                 let mut gobbled = 0;
                 while text.len() > gobbled {
-                    let mut rest = &text[gobbled..];
+                    let rest = &text[gobbled..];
                     eprintln!("Line still contains {} ({})", rest, gobbled);
                     if rest.len() + prefix.len() > columns {
                         // Try and find the largest prefix of `text` that fits within `columns`.


### PR DESCRIPTION
Building with mozilla-central fails because of these warnings about unnecessary `mut` (that I think treated as error there).

