### PR TITLE
Fixing warnings

### DIFF
--- a/crates/binjs_es6/src/scopes.rs
+++ b/crates/binjs_es6/src/scopes.rs
@@ -157,7 +157,7 @@ impl AnnotationVisitor {
                 //   This scope: is_leaving_function_scope
                 //   Or, it could have already been in the parent scope from a sibling block.
                 // Or everything together, so we don't forget if the binding was closed over.
-                if let Some(mut parent_free) = self.free_names_in_block_stack.last_mut() {
+                if let Some(parent_free) = self.free_names_in_block_stack.last_mut() {
                     let my_contribution = old_cross_function || is_leaving_function_scope;
                     parent_free
                         .entry(name)

--- a/crates/binjs_io/src/binjs_json/write.rs
+++ b/crates/binjs_io/src/binjs_json/write.rs
@@ -91,7 +91,7 @@ impl TokenWriter for TreeTokenWriter {
 
     fn enter_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         tag: &InterfaceName,
         _children: &[&FieldName],
         _path: &Path,
@@ -101,7 +101,7 @@ impl TokenWriter for TreeTokenWriter {
     }
     fn exit_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         _tag: &InterfaceName,
         children: &[&FieldName],
         _path: &Path,

--- a/crates/binjs_io/src/bytes/compress.rs
+++ b/crates/binjs_io/src/bytes/compress.rs
@@ -125,7 +125,6 @@ impl Compression {
                 data.len()
             }
             Compression::Gzip => {
-                use flate2;
                 out.write_all(b"gzip;")?;
                 // Compress
                 let buffer = Vec::with_capacity(data.len());
@@ -139,7 +138,6 @@ impl Compression {
                 buffer.len()
             }
             Compression::Deflate => {
-                use flate2;
                 out.write_all(b"deflate;")?;
                 // Compress
                 let buffer = Vec::with_capacity(data.len());
@@ -153,7 +151,6 @@ impl Compression {
                 buffer.len()
             }
             Compression::Brotli => {
-                use brotli;
                 out.write_all(b"br;")?;
                 // Compress
                 let mut buffer = Vec::with_capacity(data.len());
@@ -172,7 +169,6 @@ impl Compression {
                 buffer.len()
             }
             Compression::Lzw => {
-                use lzw;
                 out.write_all(b"compress;")?;
                 // Compress
                 let mut buffer = Vec::with_capacity(data.len());
@@ -251,21 +247,18 @@ impl Compression {
         let decompressed_bytes = match compression {
             Compression::Identity => compressed_bytes,
             Compression::Gzip => {
-                use flate2;
                 let mut decoder = flate2::read::GzDecoder::new(Cursor::new(&compressed_bytes));
                 let mut buf = Vec::with_capacity(1024);
                 decoder.read_to_end(&mut buf)?;
                 buf
             }
             Compression::Deflate => {
-                use flate2;
                 let mut decoder = flate2::read::ZlibDecoder::new(Cursor::new(&compressed_bytes));
                 let mut buf = Vec::with_capacity(1024);
                 decoder.read_to_end(&mut buf)?;
                 buf
             }
             Compression::Brotli => {
-                use brotli;
                 let mut decoder =
                     brotli::Decompressor::new(Cursor::new(&compressed_bytes), BROTLI_BUFFER_SIZE);
                 let mut buf = Vec::with_capacity(1024);
@@ -273,7 +266,6 @@ impl Compression {
                 buf
             }
             Compression::Lzw => {
-                use lzw;
                 let reader = lzw::LsbReader::new();
                 let mut decoder = lzw::Decoder::new(reader, LZW_MIN_CODE_SIZE);
                 let (_, data) = decoder.decode_bytes(&compressed_bytes)?;

--- a/crates/binjs_io/src/entropy/dictionary.rs
+++ b/crates/binjs_io/src/entropy/dictionary.rs
@@ -767,9 +767,6 @@ where
     type AsProbabilities = HashMap<K, SymbolInfo>;
 
     fn instances_to_probabilities(&self, _description: &str) -> HashMap<K, SymbolInfo> {
-        use std::cell::RefCell;
-        use std::rc::Rc;
-
         let instances = self
             .values()
             .map(|x| {
@@ -1161,7 +1158,7 @@ impl<'a> TokenWriter for &'a mut DictionaryBuilder {
 
     fn enter_tagged_tuple_at(
         &mut self,
-        node: &Node,
+        node: &dyn Node,
         tag: &InterfaceName,
         children: &[&FieldName],
         path: &IOPath,
@@ -1303,7 +1300,7 @@ impl TokenWriter for DictionaryBuilder {
 
     fn enter_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         tag: &InterfaceName,
         _children: &[&FieldName],
         path: &IOPath,

--- a/crates/binjs_io/src/entropy/mod.rs
+++ b/crates/binjs_io/src/entropy/mod.rs
@@ -273,8 +273,6 @@ impl ::FormatProvider for FormatProvider {
         spec: &binjs_meta::spec::Spec,
         matches: Option<&clap::ArgMatches>,
     ) -> Result<::Format, ::std::io::Error> {
-        use bincode;
-
         let matches = matches.unwrap();
 
         let dictionaries = match matches.value_of("dictionary") {

--- a/crates/binjs_io/src/entropy/write/mod.rs
+++ b/crates/binjs_io/src/entropy/write/mod.rs
@@ -345,7 +345,7 @@ impl Encoder {
             let maybe_dump_path = match maybe_path {
                 None => None,
                 Some(path) => {
-                    let mut buf = path
+                    let buf = path
                         .with_extension("streams")
                         .join(name)
                         .with_extension("content");
@@ -502,7 +502,7 @@ impl TokenWriter for Encoder {
 
     fn enter_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         tag: &InterfaceName,
         _children: &[&FieldName],
         path: &Path,

--- a/crates/binjs_io/src/escaped_wtf8.rs
+++ b/crates/binjs_io/src/escaped_wtf8.rs
@@ -42,8 +42,8 @@ fn is_trail_surrogate(n: u16) -> bool {
 /// Convert 0-F number to ASCII char.
 fn encode_hex_char(n: u8) -> u8 {
     match n {
-        0...9 => b'0' + n,
-        0xa...0xf => b'A' + (n - 10),
+        0..=9 => b'0' + n,
+        0xa..=0xf => b'A' + (n - 10),
         _ => panic!("unexpected input"),
     }
 }
@@ -51,9 +51,9 @@ fn encode_hex_char(n: u8) -> u8 {
 /// Convert 0-9A-Fa-f chars to number.
 fn decode_hex_char(n: u8) -> u16 {
     match n {
-        b'0'...b'9' => (n - b'0') as u16,
-        b'A'...b'F' => (n - b'A' + 10) as u16,
-        b'a'...b'f' => (n - b'a' + 10) as u16,
+        b'0'..=b'9' => (n - b'0') as u16,
+        b'A'..=b'F' => (n - b'A' + 10) as u16,
+        b'a'..=b'f' => (n - b'a' + 10) as u16,
         _ => panic!("unexpected char"),
     }
 }

--- a/crates/binjs_io/src/io/deprecated.rs
+++ b/crates/binjs_io/src/io/deprecated.rs
@@ -136,7 +136,7 @@ where
 
     fn enter_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         _tag: &InterfaceName,
         _children: &[&FieldName],
         _path: &Path,
@@ -147,7 +147,7 @@ where
 
     fn exit_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         tag: &InterfaceName,
         children: &[&FieldName],
         _path: &Path,

--- a/crates/binjs_io/src/io/mod.rs
+++ b/crates/binjs_io/src/io/mod.rs
@@ -300,14 +300,14 @@ pub trait TokenWriter {
     /// with no children.
     fn enter_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         _tag: &InterfaceName,
         _children: &[&FieldName],
         _path: &Path,
     ) -> Result<(), TokenWriterError>;
     fn exit_tagged_tuple_at(
         &mut self,
-        _node: &Node,
+        _node: &dyn Node,
         _tag: &InterfaceName,
         _children: &[&FieldName],
         _path: &Path,
@@ -422,7 +422,7 @@ where
 {
 }
 pub trait TokenSerializerFamily<T> {
-    fn make<W>(&self, writer: W) -> Box<RootedTokenSerializer<W, T>>
+    fn make<W>(&self, writer: W) -> Box<dyn RootedTokenSerializer<W, T>>
     where
         W: TokenWriter;
 }

--- a/crates/binjs_io/src/lib.rs
+++ b/crates/binjs_io/src/lib.rs
@@ -255,7 +255,7 @@ pub enum Format {
 impl Distribution<Format> for Standard {
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &'a mut R) -> Format {
         let generators = [
-            Rc::new(|_| Format::simple()) as Rc<Fn(&'a mut R) -> Format>,
+            Rc::new(|_| Format::simple()) as Rc<dyn Fn(&'a mut R) -> Format>,
             Rc::new(|rng| {
                 use multipart::{Statistics, Targets};
                 let stats = Rc::new(RefCell::new(Statistics::default().with_source_bytes(0)));
@@ -272,7 +272,7 @@ impl Distribution<Format> for Standard {
             Rc::new(|_| Format::XML),
             Rc::new(|_| Format::JSON),
         ];
-        let pick: Rc<Fn(&'a mut R) -> Format> = generators.choose(rng).map(Rc::clone).unwrap(); // Never empty
+        let pick: Rc<dyn Fn(&'a mut R) -> Format> = generators.choose(rng).map(Rc::clone).unwrap(); // Never empty
         pick(rng)
     }
 }
@@ -348,7 +348,7 @@ impl Format {
 
     /// Return all existing format providers, to manage
     /// command-line arguments.
-    fn providers() -> [&'static FormatProvider; 5] {
+    fn providers() -> [&'static dyn FormatProvider; 5] {
         [
             &multipart::FormatProvider,
             &simple::FormatProvider,
@@ -360,7 +360,7 @@ impl Format {
 
     /// The format provider to use if no format provider
     /// has been specified on the command-line.
-    fn default_provider() -> &'static FormatProvider {
+    fn default_provider() -> &'static dyn FormatProvider {
         &multipart::FormatProvider
     }
 

--- a/crates/binjs_io/src/multipart/mod.rs
+++ b/crates/binjs_io/src/multipart/mod.rs
@@ -166,7 +166,6 @@ impl ::FormatProvider for FormatProvider {
         matches: Option<&clap::ArgMatches>,
     ) -> Result<::Format, ::std::io::Error> {
         use bytes::compress::Compression;
-        use multipart::{Statistics, Targets};
 
         use std::cell::RefCell;
         use std::rc::Rc;

--- a/src/bin/decode.rs
+++ b/src/bin/decode.rs
@@ -140,7 +140,7 @@ fn main_aux() {
 }
 
 fn parse_tree<R: Read + Seek>(
-    get_stream: &Fn() -> R,
+    get_stream: &dyn Fn() -> R,
     options: &mut Options,
 ) -> binjs::specialized::es6::ast::Script {
     let decoder = Decoder::new();


### PR DESCRIPTION
- a few instances of `mut` are now unnecessary;
- `dyn` is now required for trait objects;
- a few cases of duplicate `use`;
- `..=` replaces `...`.