### PR TITLE
Fix: Docbuild

### DIFF
--- a/crates/binjs_io/src/entropy/format.rs
+++ b/crates/binjs_io/src/entropy/format.rs
@@ -1,6 +1,6 @@
 // Fake module. This is only a placeholder for documentation.
 
 // As of this writing, doc inclusion only works on Nightly compiler.
-#![cfg_attr(feature = "unstable", doc(include = "../../../spec/entropy.md"))]
+#![cfg_attr(feature = "unstable", doc(include = "../../../../spec/entropy.md"))]
 
 #![cfg_attr(not(feature = "unstable"), doc = "To generate the format spec documentation, please use `cargo doc --features unstable`. This requires Rust Nightly.")]


### PR DESCRIPTION
Apparently, we've had a bad link in documentation forever.