### PR TITLE
Update to weedle 0.11

### DIFF
--- a/crates/binjs_meta/Cargo.toml
+++ b/crates/binjs_meta/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "https://github.com/binast/binjs-ref", branch = "mast
 Inflector = "^0.11.4"
 itertools = "^0.8"
 log = "^0.4"
-weedle = "^0.8"
+weedle = "0.11"
 
 [dev-dependencies]
 clap = "^2.0"

--- a/crates/binjs_meta/src/import.rs
+++ b/crates/binjs_meta/src/import.rs
@@ -75,7 +75,7 @@ impl Importer {
     /// ```
     pub fn import<'a>(
         sources: impl IntoIterator<Item = &'a str>,
-    ) -> Result<SpecBuilder, weedle::Err<CompleteStr<'a>>> {
+    ) -> Result<SpecBuilder, weedle::Err<(&'a str, ErrorKind)>> {
         let mut importer = Importer {
             path: Vec::with_capacity(256),
             builder: SpecBuilder::new(),
@@ -330,7 +330,9 @@ impl Importer {
             .list
             .iter()
             .map(|t| match t {
-                UnionMemberType::Single(t) => self.convert_single_type(t),
+                UnionMemberType::Single(AttributedNonAnyType { type_: t, .. }) => {
+                    self.convert_single_type(t)
+                }
                 UnionMemberType::Union(t) => self.convert_union_type(t),
             })
             .map(|t| t.spec)


### PR DESCRIPTION
This changes the dependency from nom4 to nom5 which
is helpful for avoiding duplication in mozilla-central